### PR TITLE
cargo fmt --all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.rs.rustfmt
 target/
 Cargo.lock
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 *.rs.rustfmt
 target/
 Cargo.lock
-.idea/

--- a/components/bidi/src/explicit.rs
+++ b/components/bidi/src/explicit.rs
@@ -100,7 +100,10 @@ pub fn compute(
                         // Pop everything up to and including the last Isolate status.
                         match stack.vec.pop() {
                             None |
-                            Some(Status { status: OverrideStatus::Isolate, .. }) => break,
+                            Some(Status {
+                                status: OverrideStatus::Isolate,
+                                ..
+                            }) => break,
                             _ => continue,
                         }
                     }
@@ -175,7 +178,9 @@ struct DirectionalStatusStack {
 
 impl DirectionalStatusStack {
     fn new() -> Self {
-        DirectionalStatusStack { vec: Vec::with_capacity(Level::max_explicit_depth() as usize + 2) }
+        DirectionalStatusStack {
+            vec: Vec::with_capacity(Level::max_explicit_depth() as usize + 2),
+        }
     }
 
     fn push(&mut self, level: Level, status: OverrideStatus) {

--- a/components/bidi/src/implicit.rs
+++ b/components/bidi/src/implicit.rs
@@ -40,9 +40,11 @@ pub fn resolve_weak(sequence: &IsolatingRunSequence, processing_classes: &mut [B
     fn id(x: LevelRun) -> LevelRun {
         x
     }
-    let mut indices = sequence.runs.iter().cloned().flat_map(
-        id as fn(LevelRun) -> LevelRun,
-    );
+    let mut indices = sequence
+        .runs
+        .iter()
+        .cloned()
+        .flat_map(id as fn(LevelRun) -> LevelRun);
 
     while let Some(i) = indices.next() {
         match processing_classes[i] {
@@ -183,8 +185,15 @@ pub fn resolve_neutral(
             // <http://www.unicode.org/reports/tr9/#N2>
             let new_class = match (prev_class, next_class) {
                 (L, L) => L,
-                (R, R) | (R, AN) | (R, EN) | (AN, R) | (AN, AN) | (AN, EN) | (EN, R) |
-                (EN, AN) | (EN, EN) => R,
+                (R, R) |
+                (R, AN) |
+                (R, EN) |
+                (AN, R) |
+                (AN, AN) |
+                (AN, EN) |
+                (EN, R) |
+                (EN, AN) |
+                (EN, EN) => R,
                 (_, _) => e,
             };
             for j in &ni_run {

--- a/components/bidi/src/prepare.rs
+++ b/components/bidi/src/prepare.rs
@@ -108,9 +108,9 @@ pub fn isolating_run_sequences(
             }
 
             // Get the level of the last non-removed char before the runs.
-            let pred_level = match original_classes[..start_of_seq].iter().rposition(
-                not_removed_by_x9,
-            ) {
+            let pred_level = match original_classes[..start_of_seq]
+                .iter()
+                .rposition(not_removed_by_x9) {
                 Some(idx) => levels[idx],
                 None => para_level,
             };
@@ -119,9 +119,9 @@ pub fn isolating_run_sequences(
             let succ_level = if matches!(original_classes[end_of_seq - 1], RLI | LRI | FSI) {
                 para_level
             } else {
-                match original_classes[end_of_seq..].iter().position(
-                    not_removed_by_x9,
-                ) {
+                match original_classes[end_of_seq..]
+                    .iter()
+                    .position(not_removed_by_x9) {
                     Some(idx) => levels[end_of_seq + idx],
                     None => para_level,
                 }

--- a/components/bidi/src/process.rs
+++ b/components/bidi/src/process.rs
@@ -367,9 +367,9 @@ impl<'text> BidiInfo<'text> {
 
                 seq_start = seq_end;
             }
-            max_level.lower(1).expect(
-                "Lowering embedding level below zero",
-            );
+            max_level
+                .lower(1)
+                .expect("Lowering embedding level below zero");
         }
 
         (levels, runs)

--- a/components/bidi/tests/conformance_tests.rs
+++ b/components/bidi/tests/conformance_tests.rs
@@ -303,8 +303,7 @@ fn test_gen_char_from_bidi_class() {
         RLO,
         S,
         WS,
-    ]
-    {
+    ] {
         let class_name = format!("{:?}", class);
         let sample_char = gen_char_from_bidi_class(&class_name);
         assert_eq!(BidiClass::of(sample_char), class);

--- a/components/idna/src/process.rs
+++ b/components/idna/src/process.rs
@@ -79,8 +79,7 @@ fn passes_bidi(label: &str, is_bidi_domain: bool) -> bool {
                     BidiClass::L | BidiClass::EN | BidiClass::ES | BidiClass::CS |
                         BidiClass::ET | BidiClass::ON | BidiClass::BN |
                         BidiClass::NSM
-                )
-                {
+                ) {
                     return false;
                 }
             }
@@ -132,8 +131,7 @@ fn passes_bidi(label: &str, is_bidi_domain: bool) -> bool {
                     BidiClass::R | BidiClass::AL | BidiClass::AN | BidiClass::EN |
                         BidiClass::ES | BidiClass::CS | BidiClass::ET |
                         BidiClass::ON | BidiClass::BN | BidiClass::NSM
-                )
-                {
+                ) {
                     return false;
                 }
             }
@@ -214,8 +212,7 @@ fn validate(label: &str, is_bidi_domain: bool, flags: Flags, errors: &mut Vec<Er
         Mapping::Deviation(_) => flags.transitional_processing,
         Mapping::DisallowedStd3Valid => flags.use_std3_ascii_rules,
         _ => true,
-    })
-    {
+    }) {
         errors.push(Error::ValidityCriteria);
     }
     // V7: ContextJ rules
@@ -258,8 +255,7 @@ fn processing(domain: &str, flags: Flags, errors: &mut Vec<Error>) -> String {
                                 BidiClass::of(c),
                                 BidiClass::R | BidiClass::AL | BidiClass::AN
                             )
-                        })
-                        {
+                        }) {
                             is_bidi_domain = true;
                         }
                     }

--- a/components/idna/tests/conformance_tests.rs
+++ b/components/idna/tests/conformance_tests.rs
@@ -139,9 +139,8 @@ fn unescape(input: &str) -> String {
                             match char::from_u32(((c1 * 16 + c2) * 16 + c3) * 16 + c4) {
                                 Some(c) => output.push(c),
                                 None => {
-                                    output.push_str(
-                                        &format!("\\u{:X}{:X}{:X}{:X}", c1, c2, c3, c4),
-                                    );
+                                    output
+                                        .push_str(&format!("\\u{:X}{:X}{:X}{:X}", c1, c2, c3, c4));
                                 }
                             };
                         }

--- a/components/normal/tests/conformance_tests.rs
+++ b/components/normal/tests/conformance_tests.rs
@@ -17,7 +17,13 @@ extern crate unic_normal;
 use unic_normal::StrNormalForm;
 
 
-type TestDatum = (&'static str, &'static str, &'static str, &'static str, &'static str);
+type TestDatum = (
+    &'static str,
+    &'static str,
+    &'static str,
+    &'static str,
+    &'static str,
+);
 const TEST_DATA: &'static [TestDatum] = include!("tables/conformance_tests_data.rsv");
 
 

--- a/components/ucd/normal/src/decomposition_type.rs
+++ b/components/ucd/normal/src/decomposition_type.rs
@@ -25,23 +25,23 @@ use composition::canonical_decomposition;
 #[allow(missing_docs)]
 pub enum DecompositionType {
     Canonical, // abbreviated: Can
-    Compat, // abbreviated: Com
-    Circle, // abbreviated: Enc
-    Final, // abbreviated: Fin
-    Font, // abbreviated: Font
-    Fraction, // abbreviated: Fra
-    Initial, // abbreviated: Init
-    Isolated, // abbreviated: Iso
-    Medial, // abbreviated: Med
-    Narrow, // abbreviated: Nar
-    Nobreak, // abbreviated: Nb
-    None, // abbreviated: None
-    Small, // abbreviated: Sml
-    Square, // abbreviated: Sqr
-    Sub, // abbreviated: Sub
-    Super, // abbreviated: Sup
-    Vertical, // abbreviated: Vert
-    Wide, // abbreviated: Wide
+    Compat,    // abbreviated: Com
+    Circle,    // abbreviated: Enc
+    Final,     // abbreviated: Fin
+    Font,      // abbreviated: Font
+    Fraction,  // abbreviated: Fra
+    Initial,   // abbreviated: Init
+    Isolated,  // abbreviated: Iso
+    Medial,    // abbreviated: Med
+    Narrow,    // abbreviated: Nar
+    Nobreak,   // abbreviated: Nb
+    None,      // abbreviated: None
+    Small,     // abbreviated: Sml
+    Square,    // abbreviated: Sqr
+    Sub,       // abbreviated: Sub
+    Super,     // abbreviated: Sup
+    Vertical,  // abbreviated: Vert
+    Wide,      // abbreviated: Wide
 }
 
 


### PR DESCRIPTION
This PR is the format changes suggested by the latest release of rustfmt (`rustfmt-nightly:0.1.9`).

This is a suggestion to update to that style, rather than that of the old Syntex-based rustfmt (`rusftmt:0.9.0`) which has been discontinued due to Syntex's being discontinued, in favor of using libsyntax.

Original text below.

<hr />

Because this is a monorepo with multiple Cargo.toml, `cargo +nightly fmt` doesn't format sub-crates. (If there is functionality to do so, I haven't found it, and it should likely be added.)

In order to format a subcrate you must `cd` to the directory which contains the Cargo.toml describing the crate you are working on and then run rustfmt.

In order to keep code formatted well it must first be formatted well. I don't take hitting myself with the `git blame` on so many lines lightly, but having the code formatted by the guides laid out in `.rustfmt.toml` is important, and allows future contributors to run rustfmt without formatting code they didn't change.

If there's a format change you don't want here, the answer is to tell rustfmt to format it differently; by including `.rustfmt.toml` you're encouraging contributors to rustfmt their code and that is the style guide of the repository.