### PR TITLE
Move test dependencies into [dev-dependencies]

### DIFF
--- a/components/bidi/Cargo.toml
+++ b/components/bidi/Cargo.toml
@@ -20,7 +20,7 @@ bench_it = []
 matches = "0.1"
 serde = { version = ">=0.8, <2.0", optional = true, features = ["derive"] }
 unic-ucd-bidi = { path = "../ucd/bidi/", version = "0.4.0" }
-unic-ucd-core = { path = "../ucd/core/", version = "0.4.0" }
 
 [dev-dependencies]
 serde_test = ">=0.8, <2.0"
+unic-ucd-core = { path = "../ucd/core/", version = "0.4.0" }

--- a/components/normal/Cargo.toml
+++ b/components/normal/Cargo.toml
@@ -14,5 +14,7 @@ readme = "README.md"
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
-unic-ucd-core = { path = "../ucd/core/", version = "0.4.0" }
 unic-ucd-normal = { path = "../ucd/normal/", version = "0.4.0" }
+
+[dev-dependencies]
+unic-ucd-core = { path = "../ucd/core/", version = "0.4.0" }

--- a/components/ucd/age/Cargo.toml
+++ b/components/ucd/age/Cargo.toml
@@ -13,4 +13,6 @@ travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
 unic-ucd-core = { path = "../core/", version = "0.4.0" }
+
+[dev-dependencies]
 unic-ucd-utils = { path = "../utils/", version = "0.4.0" }


### PR DESCRIPTION
A simple bookkeeping change.

No version bumps were made. No code or API was changed, just the explicit dependency chain.