### PR TITLE
Create bidi_class::abbr_names and use long names in BidiClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,11 +173,11 @@ fn main() {
     assert!(text.has_rtl());
     assert!(text.has_ltr());
 
-    assert_eq!(text.chars().nth(0).unwrap().bidi_class(), BidiClass::R);
+    assert_eq!(text.chars().nth(0).unwrap().bidi_class(), BidiClass::RightToLeft);
     assert!(!text.chars().nth(0).unwrap().is_ltr());
     assert!(text.chars().nth(0).unwrap().is_rtl());
 
-    assert_eq!(text.chars().nth(3).unwrap().bidi_class(), BidiClass::L);
+    assert_eq!(text.chars().nth(3).unwrap().bidi_class(), BidiClass::LeftToRight);
     assert!(text.chars().nth(3).unwrap().is_ltr());
     assert!(!text.chars().nth(3).unwrap().is_rtl());
 

--- a/components/bidi/src/bidi_info.rs
+++ b/components/bidi/src/bidi_info.rs
@@ -16,17 +16,18 @@ use std::fmt;
 use std::iter::repeat;
 use std::ops::Range;
 
+use unic_ucd_bidi::BidiClass;
+use unic_ucd_bidi::bidi_class::abbr_names::*;
+
 use explicit;
 use implicit;
 use level;
 use prepare;
 use format_chars;
 
-use unic_ucd_bidi::BidiClass;
 use level::{Level, LTR_LEVEL, RTL_LEVEL};
 use prepare::LevelRun;
 
-use BidiClass::*;
 
 
 /// Bidi information about a single paragraph

--- a/components/bidi/src/explicit.rs
+++ b/components/bidi/src/explicit.rs
@@ -13,11 +13,12 @@
 //!
 //! <http://www.unicode.org/reports/tr9/#Explicit_Levels_and_Directions>
 
+
 use unic_ucd_bidi::BidiClass;
+use unic_ucd_bidi::bidi_class::abbr_names::*;
 
 use super::level::Level;
 
-use BidiClass::*;
 
 /// Compute explicit embedding levels for one paragraph of text (X1-X8).
 ///

--- a/components/bidi/src/implicit.rs
+++ b/components/bidi/src/implicit.rs
@@ -14,11 +14,11 @@
 use std::cmp::max;
 
 use unic_ucd_bidi::BidiClass;
+use unic_ucd_bidi::bidi_class::abbr_names::*;
 
 use super::prepare::{IsolatingRunSequence, LevelRun, not_removed_by_x9, removed_by_x9};
 use super::level::Level;
 
-use BidiClass::*;
 
 /// 3.3.4 Resolving Weak Types
 ///

--- a/components/bidi/src/level.rs
+++ b/components/bidi/src/level.rs
@@ -15,10 +15,12 @@
 //!
 //! http://www.unicode.org/reports/tr9/#BD2
 
+
 use std::convert::{From, Into};
 use std::fmt;
 
 use unic_ucd_bidi::BidiClass;
+
 
 /// Embedding Level
 ///
@@ -189,9 +191,9 @@ impl Level {
     #[inline]
     pub fn bidi_class(&self) -> BidiClass {
         if self.is_rtl() {
-            BidiClass::R
+            BidiClass::RightToLeft
         } else {
-            BidiClass::L
+            BidiClass::LeftToRight
         }
     }
 

--- a/components/bidi/src/lib.rs
+++ b/components/bidi/src/lib.rs
@@ -88,11 +88,12 @@ mod implicit;
 mod prepare;
 
 
+pub use unic_ucd_bidi::UNICODE_VERSION;
+pub use unic_ucd_bidi::{BidiClass, bidi_class, BidiClassCategory};
+
 pub use bidi_info::{ParagraphInfo, BidiInfo};
 pub use level::Level;
 pub use prepare::LevelRun;
-pub use unic_ucd_bidi::UNICODE_VERSION;
-pub use unic_ucd_bidi::{BidiClass, BidiClassCategory};
 
 
 /// UNIC component version.

--- a/components/bidi/src/prepare.rs
+++ b/components/bidi/src/prepare.rs
@@ -17,10 +17,10 @@ use std::cmp::max;
 use std::ops::Range;
 
 use unic_ucd_bidi::BidiClass;
+use unic_ucd_bidi::bidi_class::abbr_names::*;
 
 use super::level::Level;
 
-use BidiClass::*;
 
 /// A maximal substring of characters with the same embedding level.
 ///

--- a/components/bidi/tests/conformance_tests.rs
+++ b/components/bidi/tests/conformance_tests.rs
@@ -15,7 +15,7 @@
 extern crate unic_bidi;
 
 
-use unic_bidi::{BidiClass, BidiInfo, format_chars, level, Level};
+use unic_bidi::{BidiClass, bidi_class, BidiInfo, format_chars, level, Level};
 
 
 const BASIC_TEST_DATA: &'static str = include_str!("../../../data/ucd/test/BidiTest.txt");
@@ -277,7 +277,7 @@ fn gen_char_from_bidi_class(class_name: &str) -> char {
 
 #[test]
 fn test_gen_char_from_bidi_class() {
-    use unic_bidi::BidiClass::*;
+    use self::bidi_class::abbr_names::*;
 
     for &class in &[
         AL,
@@ -304,7 +304,7 @@ fn test_gen_char_from_bidi_class() {
         S,
         WS,
     ] {
-        let class_name = format!("{:?}", class);
+        let class_name = class.abbr_name();
         let sample_char = gen_char_from_bidi_class(&class_name);
         assert_eq!(BidiClass::of(sample_char), class);
     }

--- a/components/ucd/age/src/age.rs
+++ b/components/ucd/age/src/age.rs
@@ -87,7 +87,6 @@ impl Age {
             Age::Unassigned => "Unassigned".to_owned(),
         }
     }
-
 }
 
 // TODO: Generic'ize and move to `unic-ucd-utils`

--- a/components/ucd/bidi/src/bidi_class.rs
+++ b/components/ucd/bidi/src/bidi_class.rs
@@ -22,34 +22,66 @@ use std::fmt;
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Hash)]
 #[allow(missing_docs)]
 pub enum BidiClass {
-    AL,
-    AN,
-    B,
-    BN,
-    CS,
-    EN,
-    ES,
-    ET,
-    FSI,
-    L,
-    LRE,
-    LRI,
-    LRO,
-    NSM,
-    ON,
-    PDF,
-    PDI,
-    R,
-    RLE,
-    RLI,
-    RLO,
-    S,
-    WS,
+    ArabicLetter,
+    ArabicNumber,
+    ParagraphSeparator,
+    BoundaryNeutral,
+    CommonSeparator,
+    EuropeanNumber,
+    EuropeanSeparator,
+    EuropeanTerminator,
+    FirstStrongIsolate,
+    LeftToRight,
+    LeftToRightEmbedding,
+    LeftToRightIsolate,
+    LeftToRightOverride,
+    NonspacingMark,
+    OtherNeutral,
+    PopDirectionalFormat,
+    PopDirectionalIsolate,
+    RightToLeft,
+    RightToLeftEmbedding,
+    RightToLeftIsolate,
+    RightToLeftOverride,
+    SegmentSeparator,
+    WhiteSpace,
     // [UNIC_UPDATE_ON_UNICODE_UPDATE] Source: `tables/bidi_class_type.rsv`
 }
 
 
-use self::BidiClass::*;
+/// Abbreviated name aliases for
+/// [*Bidi_Class*](http://www.unicode.org/reports/tr44/#Bidi_Class) property.
+///
+/// <http://www.unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt#Bidi_Class>
+pub mod abbr_names {
+    pub use BidiClass::ArabicLetter as AL;
+    pub use BidiClass::ArabicNumber as AN;
+    pub use BidiClass::ParagraphSeparator as B;
+    pub use BidiClass::BoundaryNeutral as BN;
+    pub use BidiClass::CommonSeparator as CS;
+    pub use BidiClass::EuropeanNumber as EN;
+    pub use BidiClass::EuropeanSeparator as ES;
+    pub use BidiClass::EuropeanTerminator as ET;
+    pub use BidiClass::FirstStrongIsolate as FSI;
+    pub use BidiClass::LeftToRight as L;
+    pub use BidiClass::LeftToRightEmbedding as LRE;
+    pub use BidiClass::LeftToRightIsolate as LRI;
+    pub use BidiClass::LeftToRightOverride as LRO;
+    pub use BidiClass::NonspacingMark as NSM;
+    pub use BidiClass::OtherNeutral as ON;
+    pub use BidiClass::PopDirectionalFormat as PDF;
+    pub use BidiClass::PopDirectionalIsolate as PDI;
+    pub use BidiClass::RightToLeft as R;
+    pub use BidiClass::RightToLeftEmbedding as RLE;
+    pub use BidiClass::RightToLeftIsolate as RLI;
+    pub use BidiClass::RightToLeftOverride as RLO;
+    pub use BidiClass::SegmentSeparator as S;
+    pub use BidiClass::WhiteSpace as WS;
+    // [UNIC_UPDATE_ON_UNICODE_UPDATE] Source: `tables/bidi_class_type.rsv`
+}
+
+
+use self::abbr_names::*;
 
 const BIDI_CLASS_TABLE: &'static [(char, char, BidiClass)] =
     include!("tables/bidi_class_values.rsv");
@@ -74,12 +106,41 @@ pub enum BidiClassCategory {
     Neutral,
 }
 
-use self::BidiClassCategory::*;
-
 impl BidiClass {
     /// Find the BidiClass of a single char.
     pub fn of(ch: char) -> BidiClass {
         bsearch_range_value_table(ch, BIDI_CLASS_TABLE)
+    }
+
+    /// Abbreviated name of the Bidi Class property value.
+    ///
+    /// <http://www.unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt#Bidi_Class>
+    pub fn abbr_name(&self) -> &str {
+        match *self {
+            BidiClass::ArabicLetter => "AL",
+            BidiClass::ArabicNumber => "AN",
+            BidiClass::ParagraphSeparator => "B",
+            BidiClass::BoundaryNeutral => "BN",
+            BidiClass::CommonSeparator => "CS",
+            BidiClass::EuropeanNumber => "EN",
+            BidiClass::EuropeanSeparator => "ES",
+            BidiClass::EuropeanTerminator => "ET",
+            BidiClass::FirstStrongIsolate => "FSI",
+            BidiClass::LeftToRight => "L",
+            BidiClass::LeftToRightEmbedding => "LRE",
+            BidiClass::LeftToRightIsolate => "LRI",
+            BidiClass::LeftToRightOverride => "LRO",
+            BidiClass::NonspacingMark => "NSM",
+            BidiClass::OtherNeutral => "ON",
+            BidiClass::PopDirectionalFormat => "PDF",
+            BidiClass::PopDirectionalIsolate => "PDI",
+            BidiClass::RightToLeft => "R",
+            BidiClass::RightToLeftEmbedding => "RLE",
+            BidiClass::RightToLeftIsolate => "RLI",
+            BidiClass::RightToLeftOverride => "RLO",
+            BidiClass::SegmentSeparator => "S",
+            BidiClass::WhiteSpace => "WS",
+        }
     }
 
     /// Human-readable description of the Bidi Class property value.
@@ -125,10 +186,12 @@ impl BidiClass {
     #[inline]
     pub fn category(&self) -> BidiClassCategory {
         match *self {
-            L | R | AL => Strong,
-            EN | ES | ET | AN | CS | NSM | BN => Weak,
-            B | S | WS | ON => Neutral,
-            LRE | LRO | RLE | RLO | PDF | LRI | RLI | FSI | PDI => ExplicitFormatting,
+            L | R | AL => BidiClassCategory::Strong,
+            EN | ES | ET | AN | CS | NSM | BN => BidiClassCategory::Weak,
+            B | S | WS | ON => BidiClassCategory::Neutral,
+            LRE | LRO | RLE | RLO | PDF | LRI | RLI | FSI | PDI => {
+                BidiClassCategory::ExplicitFormatting
+            }
         }
     }
 
@@ -179,7 +242,7 @@ impl fmt::Display for BidiClass {
 #[cfg(test)]
 mod tests {
     use super::BidiClass;
-    use BidiClass::*;
+    use super::abbr_names::*;
 
     #[test]
     fn test_ascii() {
@@ -264,9 +327,9 @@ mod tests {
 
     #[test]
     fn test_display() {
-        assert_eq!(format!("{}", BidiClass::L), "Left-to-Right");
-        assert_eq!(format!("{}", BidiClass::R), "Right-to-Left");
-        assert_eq!(format!("{}", BidiClass::AL), "Right-to-Left Arabic");
-        assert_eq!(format!("{}", BidiClass::FSI), "First Strong Isolate");
+        assert_eq!(format!("{}", L), "Left-to-Right");
+        assert_eq!(format!("{}", R), "Right-to-Left");
+        assert_eq!(format!("{}", AL), "Right-to-Left Arabic");
+        assert_eq!(format!("{}", FSI), "First Strong Isolate");
     }
 }

--- a/components/ucd/bidi/src/lib.rs
+++ b/components/ucd/bidi/src/lib.rs
@@ -22,7 +22,9 @@
 extern crate unic_ucd_core;
 
 
-mod bidi_class;
+/// Unicode *Bidi_Class* Character Property.
+pub mod bidi_class;
+
 mod traits;
 
 pub use bidi_class::{BidiClass, BidiClassCategory};

--- a/components/ucd/bidi/src/traits.rs
+++ b/components/ucd/bidi/src/traits.rs
@@ -78,22 +78,22 @@ impl StrBidiClass for str {
 mod tests {
     #[test]
     fn test_bidi_char() {
-        use super::{CharBidiClass, BidiClass, BidiClassCategory};
+        use super::{BidiClass, BidiClassCategory, CharBidiClass};
 
         let ch = '\u{0041}'; // U+0041 LATIN CAPITAL LETTER A "A"
-        assert_eq!(ch.bidi_class(), BidiClass::L);
+        assert_eq!(ch.bidi_class(), BidiClass::LeftToRight);
         assert_eq!(ch.bidi_class().category(), BidiClassCategory::Strong);
         assert!(ch.is_ltr());
         assert!(!ch.is_rtl());
 
         let ch = '\u{05D0}'; // U+05D0 HEBREW LETTER ALEF "א"
-        assert_eq!(ch.bidi_class(), BidiClass::R);
+        assert_eq!(ch.bidi_class(), BidiClass::RightToLeft);
         assert_eq!(ch.bidi_class().category(), BidiClassCategory::Strong);
         assert!(!ch.is_ltr());
         assert!(ch.is_rtl());
 
         let ch = '\u{0627}'; // U+0627 ARABIC LETTER ALEF "ا"
-        assert_eq!(ch.bidi_class(), BidiClass::AL);
+        assert_eq!(ch.bidi_class(), BidiClass::ArabicLetter);
         assert_eq!(ch.bidi_class().category(), BidiClassCategory::Strong);
         assert!(!ch.is_ltr());
         assert!(ch.is_rtl());

--- a/components/ucd/category/src/category.rs
+++ b/components/ucd/category/src/category.rs
@@ -97,6 +97,7 @@ impl GeneralCategory {
     pub fn is_cased_letter(&self) -> bool {
         matches!(*self, UppercaseLetter | LowercaseLetter | TitlecaseLetter)
     }
+
     /// `Lu` | `Ll` | `Lt` | `Lm` | `Lo`  (Short form: `L`)
     pub fn is_letter(&self) -> bool {
         matches!(
@@ -104,14 +105,17 @@ impl GeneralCategory {
             UppercaseLetter | LowercaseLetter | TitlecaseLetter | ModifierLetter | OtherLetter
         )
     }
+
     /// `Mn` | `Mc` | `Me`  (Short form: `M`)
     pub fn is_mark(&self) -> bool {
         matches!(*self, NonspacingMark | SpacingMark | EnclosingMark)
     }
+
     /// `Nd` | `Nl` | `No`  (Short form: `N`)
     pub fn is_number(&self) -> bool {
         matches!(*self, DecimalNumber | LetterNumber | OtherNumber)
     }
+
     /// `Pc` | `Pd` | `Ps` | `Pe` | `Pi` | `Pf` | `Po`  (Short form: `P`)
     pub fn is_punctuation(&self) -> bool {
         matches!(
@@ -120,6 +124,7 @@ impl GeneralCategory {
                 InitialPunctuation | FinalPunctuation | OtherPunctuation
         )
     }
+
     /// `Sm` | `Sc` | `Sk` | `So`  (Short form: `S`)
     pub fn is_symbol(&self) -> bool {
         matches!(
@@ -127,10 +132,12 @@ impl GeneralCategory {
             MathSymbol | CurrencySymbol | ModifierLetter | OtherSymbol
         )
     }
+
     /// `Zs` | `Zl` | `Zp`  (Short form: `Z`)
     pub fn is_separator(&self) -> bool {
         matches!(*self, SpaceSeparator | LineSeparator | ParagraphSeparator)
     }
+
     /// `Cc` | `Cf` | `Cs` | `Co` | `Cn`  (Short form: `C`)
     pub fn is_other(&self) -> bool {
         matches!(
@@ -170,6 +177,7 @@ mod tests {
             let c = char::from_u32(c).unwrap();
             assert_eq!(GC::of(c), GC::Control);
         }
+
         assert_eq!(GC::of(' '), GC::SpaceSeparator);
         assert_eq!(GC::of('!'), GC::OtherPunctuation);
         assert_eq!(GC::of('"'), GC::OtherPunctuation);
@@ -186,10 +194,12 @@ mod tests {
         assert_eq!(GC::of('-'), GC::DashPunctuation);
         assert_eq!(GC::of('.'), GC::OtherPunctuation);
         assert_eq!(GC::of('/'), GC::OtherPunctuation);
+
         for c in ('0' as u32)..('9' as u32 + 1) {
             let c = char::from_u32(c).unwrap();
             assert_eq!(GC::of(c), GC::DecimalNumber);
         }
+
         assert_eq!(GC::of(':'), GC::OtherPunctuation);
         assert_eq!(GC::of(';'), GC::OtherPunctuation);
         assert_eq!(GC::of('<'), GC::MathSymbol);
@@ -197,20 +207,24 @@ mod tests {
         assert_eq!(GC::of('>'), GC::MathSymbol);
         assert_eq!(GC::of('?'), GC::OtherPunctuation);
         assert_eq!(GC::of('@'), GC::OtherPunctuation);
+
         for c in ('A' as u32)..('Z' as u32 + 1) {
             let c = char::from_u32(c).unwrap();
             assert_eq!(GC::of(c), GC::UppercaseLetter);
         }
+
         assert_eq!(GC::of('['), GC::OpenPunctuation);
         assert_eq!(GC::of('\\'), GC::OtherPunctuation);
         assert_eq!(GC::of(']'), GC::ClosePunctuation);
         assert_eq!(GC::of('^'), GC::ModifierSymbol);
         assert_eq!(GC::of('_'), GC::ConnectorPunctuation);
         assert_eq!(GC::of('`'), GC::ModifierSymbol);
+
         for c in ('a' as u32)..('z' as u32 + 1) {
             let c = char::from_u32(c).unwrap();
             assert_eq!(GC::of(c), GC::LowercaseLetter);
         }
+
         assert_eq!(GC::of('{'), GC::OpenPunctuation);
         assert_eq!(GC::of('|'), GC::MathSymbol);
         assert_eq!(GC::of('}'), GC::ClosePunctuation);
@@ -226,6 +240,7 @@ mod tests {
         assert_eq!(GC::of('￼'), GC::OtherSymbol);
         // 0xFFFD REPLACEMENT CHARACTER
         assert_eq!(GC::of('�'), GC::OtherSymbol);
+
         for &c in [0xFFEF, 0xFFFE, 0xFFFF].iter() {
             let c = char::from_u32(c).unwrap();
             assert_eq!(GC::of(c), GC::Unassigned);
@@ -238,10 +253,12 @@ mod tests {
             let c = char::from_u32(c).unwrap();
             assert_eq!(GC::of(c), GC::PrivateUse);
         }
+
         for c in 0x100000..(0x10FFFD + 1) {
             let c = char::from_u32(c).unwrap();
             assert_eq!(GC::of(c), GC::PrivateUse);
         }
+
         for &c in [0xFFFFE, 0xFFFFF, 0x10FFFE, 0x10FFFF].iter() {
             let c = char::from_u32(c).unwrap();
             assert_eq!(GC::of(c), GC::Unassigned);

--- a/components/ucd/tests/category_tests.rs
+++ b/components/ucd/tests/category_tests.rs
@@ -27,7 +27,7 @@ use unic_ucd::utils::iter_all_chars;
 fn test_bidi_nsm_against_gen_cat() {
     // Every NSM must be a GC=Mark
     for cp in iter_all_chars() {
-        if BidiClass::of(cp) == BidiClass::NSM {
+        if BidiClass::of(cp) == BidiClass::NonspacingMark {
             assert!(is_combining_mark(cp));
         }
     }
@@ -35,7 +35,7 @@ fn test_bidi_nsm_against_gen_cat() {
     // Every GC!=Mark must not be an NSM
     for cp in iter_all_chars() {
         if !is_combining_mark(cp) {
-            assert_ne!(BidiClass::of(cp), BidiClass::NSM);
+            assert_ne!(BidiClass::of(cp), BidiClass::NonspacingMark);
         }
     }
 }

--- a/examples/ucd_bidi_traits_example.rs
+++ b/examples/ucd_bidi_traits_example.rs
@@ -32,7 +32,7 @@ fn main() {
     assert!(text.has_rtl());
     assert!(text.has_ltr());
 
-    assert_eq!(text.chars().nth(0).unwrap().bidi_class(), BidiClass::R);
+    assert_eq!(text.chars().nth(0).unwrap().bidi_class(), BidiClass::RightToLeft);
     assert_eq!(
         text.chars().nth(0).unwrap().bidi_class().category(),
         BidiClassCategory::Strong
@@ -40,7 +40,7 @@ fn main() {
     assert!(!text.chars().nth(0).unwrap().is_ltr());
     assert!(text.chars().nth(0).unwrap().is_rtl());
 
-    assert_eq!(text.chars().nth(3).unwrap().bidi_class(), BidiClass::L);
+    assert_eq!(text.chars().nth(3).unwrap().bidi_class(), BidiClass::LeftToRight);
     assert_eq!(
         text.chars().nth(0).unwrap().bidi_class().category(),
         BidiClassCategory::Strong

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,11 +71,11 @@
 //!     assert!(text.has_rtl());
 //!     assert!(text.has_ltr());
 //!
-//!     assert_eq!(text.chars().nth(0).unwrap().bidi_class(), BidiClass::R);
+//!     assert_eq!(text.chars().nth(0).unwrap().bidi_class(), BidiClass::RightToLeft);
 //!     assert!(!text.chars().nth(0).unwrap().is_ltr());
 //!     assert!(text.chars().nth(0).unwrap().is_rtl());
 //!
-//!     assert_eq!(text.chars().nth(3).unwrap().bidi_class(), BidiClass::L);
+//!     assert_eq!(text.chars().nth(3).unwrap().bidi_class(), BidiClass::LeftToRight);
 //!     assert!(text.chars().nth(3).unwrap().is_ltr());
 //!     assert!(!text.chars().nth(3).unwrap().is_rtl());
 //!

--- a/tests/basics_test.rs
+++ b/tests/basics_test.rs
@@ -53,11 +53,11 @@ fn test_sample() {
     assert!(text.has_rtl());
     assert!(text.has_ltr());
 
-    assert_eq!(text.chars().nth(0).unwrap().bidi_class(), BidiClass::R);
+    assert_eq!(text.chars().nth(0).unwrap().bidi_class(), BidiClass::RightToLeft);
     assert!(!text.chars().nth(0).unwrap().is_ltr());
     assert!(text.chars().nth(0).unwrap().is_rtl());
 
-    assert_eq!(text.chars().nth(3).unwrap().bidi_class(), BidiClass::L);
+    assert_eq!(text.chars().nth(3).unwrap().bidi_class(), BidiClass::LeftToRight);
     assert!(text.chars().nth(3).unwrap().is_ltr());
     assert!(!text.chars().nth(3).unwrap().is_rtl());
 


### PR DESCRIPTION
Update the rest of code-base to use the new enum variant names and
aliases.

Closes <https://github.com/behnam/rust-unic/issues/37>