### PR TITLE
[Cargo] Exclude tools, data and data-dependent tests/benches in packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.rs.rustfmt
 target/
 Cargo.lock
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 *.rs.rustfmt
 target/
 Cargo.lock
-.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,13 @@ description = "UNIC - Unicode and Internationalization Crates"
 categories = ["parsing", "rendering", "encoding", "development-tools"]
 readme = "README.md"
 
+exclude = [
+    "data/**/*.txt",
+    "tools/**/*.py",
+    ".cargo/*.sh",
+    "tests/*conformance*.rs",
+]
+
 [workspace]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,11 @@ categories = ["parsing", "rendering", "encoding", "development-tools"]
 readme = "README.md"
 
 exclude = [
-    "data/**/*.txt",
-    "tools/**/*.py",
-    ".cargo/*.sh",
+    "data/**",
+    "tools/**",
+    ".cargo/**",
+    # Only ignore conformance tests;
+    # Those are the ones that rely on data files
     "tests/*conformance*.rs",
 ]
 

--- a/components/bidi/Cargo.toml
+++ b/components/bidi/Cargo.toml
@@ -9,6 +9,8 @@ keywords = ["text", "unicode", "rtl", "layout", "bidi"]
 description = "UNIC - Unicode Bidirectional Algorithm"
 readme = "README.md"
 
+exclude = [ "tests/*conformance*.rs" ]
+
 [badges]
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 

--- a/components/idna/Cargo.toml
+++ b/components/idna/Cargo.toml
@@ -9,6 +9,8 @@ keywords = ["text", "unicode"]
 description = "UNIC - Unicode IDNA Compatibility Processing"
 readme = "README.md"
 
+exclude = [ "tests/*conformance*.rs" ]
+
 [badges]
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 

--- a/components/normal/Cargo.toml
+++ b/components/normal/Cargo.toml
@@ -10,6 +10,8 @@ description = "UNIC - Unicode Normalization Forms"
 categories = ["parsing", "rendering", "encoding", "development-tools"]
 readme = "README.md"
 
+exclude = [ "tests/*conformance*.rs" ]
+
 [badges]
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 

--- a/components/ucd/Cargo.toml
+++ b/components/ucd/Cargo.toml
@@ -9,6 +9,8 @@ keywords = ["text", "unicode"]
 description = "UNIC - Unicode Character Database"
 readme = "README.md"
 
+exclude = [ "tests/*conformance*.rs" ]
+
 [badges]
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 

--- a/components/ucd/age/Cargo.toml
+++ b/components/ucd/age/Cargo.toml
@@ -8,6 +8,8 @@ license = "MIT/Apache-2.0"
 keywords = ["text", "unicode"]
 description = "UNIC - Unicode Character Database - Age"
 
+exclude = [ "tests/*conformance*.rs" ]
+
 [badges]
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 

--- a/components/ucd/bidi/Cargo.toml
+++ b/components/ucd/bidi/Cargo.toml
@@ -8,6 +8,8 @@ license = "MIT/Apache-2.0"
 keywords = ["text", "unicode"]
 description = "UNIC - Unicode Character Database - Bidi Properties"
 
+exclude = [ "tests/*conformance*.rs" ]
+
 [badges]
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 

--- a/components/ucd/category/Cargo.toml
+++ b/components/ucd/category/Cargo.toml
@@ -8,6 +8,8 @@ license = "MIT/Apache-2.0"
 keywords = ["text", "unicode"]
 description = "UNIC - Unicode Character Database - General Category"
 
+exclude = [ "tests/*conformance*.rs" ]
+
 [badges]
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 

--- a/components/ucd/core/Cargo.toml
+++ b/components/ucd/core/Cargo.toml
@@ -8,5 +8,7 @@ license = "MIT/Apache-2.0"
 keywords = ["text", "unicode"]
 description = "UNIC - Unicode Character Database - Version"
 
+exclude = [ "tests/*conformance*.rs" ]
+
 [badges]
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }

--- a/components/ucd/normal/Cargo.toml
+++ b/components/ucd/normal/Cargo.toml
@@ -8,6 +8,8 @@ license = "MIT/Apache-2.0"
 keywords = ["text", "unicode"]
 description = "UNIC - Unicode Character Database - Normalization Properties"
 
+exclude = [ "tests/*conformance*.rs" ]
+
 [badges]
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 

--- a/components/ucd/utils/Cargo.toml
+++ b/components/ucd/utils/Cargo.toml
@@ -8,5 +8,7 @@ license = "MIT/Apache-2.0"
 keywords = ["text", "unicode"]
 description = "UNIC - Utilities for working with Unicode Code Points"
 
+exclude = [ "tests/*conformance*.rs" ]
+
 [badges]
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }


### PR DESCRIPTION
Should close #34 

I'm not exactly certain how to reproduce a "download from Crates.io" locally to see if the package A) builds and B) tests successfully, but looking at the output of `cargo package --allow-dirty --list` looks optimistic.

The benefit of closing #34 will be to remove the `data/` directory from the root crate (currently ~21MiB) and allowing the subcrates to pass their tests locally without being in this repository layout.

If someone can test to make sure that those two things are true of the package, then this should be good to merge.