### PR TITLE
[travis] Drop allow_failures for nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ rust:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - rust: nightly
 
 notifications:
   email:


### PR DESCRIPTION
This will increase the time waiting for CI tests to pass, but we care
about the nightly test to pass and features depending on nightly to be
stable. So, better just drop `allow_failures`.