### PR TITLE
[ucd/category] Fix typo in GeneralCategory::is_symbol()

### DIFF
--- a/unic/ucd/category/src/category.rs
+++ b/unic/ucd/category/src/category.rs
@@ -129,7 +129,7 @@ impl GeneralCategory {
     pub fn is_symbol(&self) -> bool {
         matches!(
             *self,
-            MathSymbol | CurrencySymbol | ModifierLetter | OtherSymbol
+            MathSymbol | CurrencySymbol | ModifierSymbol | OtherSymbol
         )
     }
 


### PR DESCRIPTION
While I was working on #43 I found this typo which was causing one of my tests to fail.

I haven't finished #43 yet but I figured I may as well fix the typo asap.

My first ever PR! :') 