### PR TITLE
[ucd] Extend cross-component tests: GeneralCategory vs. BidiClass

### DIFF
--- a/unic/ucd/Cargo.toml
+++ b/unic/ucd/Cargo.toml
@@ -24,3 +24,4 @@ unic-ucd-category = { path = "category/", version = "0.4.0" }
 
 [dev-dependencies]
 unic-utils = { path = "../utils/", version = "0.4.0" }
+matches = "0.1"

--- a/unic/ucd/tests/category_tests.rs
+++ b/unic/ucd/tests/category_tests.rs
@@ -16,10 +16,85 @@ extern crate unic_ucd;
 extern crate unic_utils;
 
 
-use unic_ucd::bidi::BidiClass;
+use unic_ucd::bidi::BidiClass as BC;
 use unic_ucd::normal::is_combining_mark;
+use unic_ucd::category::GeneralCategory as GC;
 use unic_utils::iter_all_chars;
 
+/// `normal::is_combining_mark` and `GeneralCategory::is_mark()` are expected to return
+/// the same results.
+#[test]
+fn test_gen_cat_against_normal() {
+    for cp in iter_all_chars() {
+        assert_eq!(GC::of(cp).is_mark(), is_combining_mark(cp));
+    }
+}
+
+/// <http://www.unicode.org/reports/tr9/#EN>
+#[test]
+fn test_bidi_en_against_gen_cat() {
+    for cp in iter_all_chars() {
+        if BC::of(cp) == BC::EuropeanNumber {
+            assert!(GC::of(cp).is_number());
+        }
+    }
+}
+
+/// <http://www.unicode.org/reports/tr9/#ES>
+#[test]
+fn test_bidi_es_against_gen_cat() {
+    for cp in iter_all_chars() {
+        if BC::of(cp) == BC::EuropeanSeparator {
+            assert!(
+                GC::of(cp) == GC::MathSymbol ||
+                GC::of(cp) == GC::DashPunctuation
+            );
+        }
+    }
+}
+
+/// <http://www.unicode.org/reports/tr9/#ET>
+#[test]
+fn test_bidi_et_against_gen_cat() {
+    for cp in iter_all_chars() {
+        if BC::of(cp) == BC::EuropeanTerminator {
+            assert!(
+                GC::of(cp).is_symbol()          ||
+                GC::of(cp) == GC::Unassigned    ||
+                GC::of(cp) == GC::OtherPunctuation
+            );
+        }
+    }
+}
+
+/// <http://www.unicode.org/reports/tr9/#AN>
+#[test]
+fn test_bidi_an_against_gen_cat() {
+    for cp in iter_all_chars() {
+        if BC::of(cp) == BC::ArabicNumber {
+            assert!(
+                GC::of(cp) == GC::Format            ||
+                GC::of(cp) == GC::OtherNumber       ||
+                GC::of(cp) == GC::OtherPunctuation  ||
+                GC::of(cp) == GC::DecimalNumber
+            );
+        }
+    }
+}
+
+/// <http://www.unicode.org/reports/tr9/#CS>
+#[test]
+fn test_bidi_cs_against_gen_cat() {
+    for cp in iter_all_chars() {
+        if BC::of(cp) == BC::CommonSeparator {
+            assert!(
+                GC::of(cp) == GC::OtherPunctuation  ||
+                GC::of(cp) == GC::SpaceSeparator    ||
+                GC::of(cp) == GC::MathSymbol
+            );
+        }
+    }
+}
 
 /// `Bidi_Class=NSM := General_Category in { Mn (Nonspacing_Mark), Me (Enclosing_Mark) }`
 ///
@@ -28,7 +103,7 @@ use unic_utils::iter_all_chars;
 fn test_bidi_nsm_against_gen_cat() {
     // Every NSM must be a GC=Mark
     for cp in iter_all_chars() {
-        if BidiClass::of(cp) == BidiClass::NonspacingMark {
+        if BC::of(cp) == BC::NonspacingMark {
             assert!(is_combining_mark(cp));
         }
     }
@@ -36,7 +111,54 @@ fn test_bidi_nsm_against_gen_cat() {
     // Every GC!=Mark must not be an NSM
     for cp in iter_all_chars() {
         if !is_combining_mark(cp) {
-            assert_ne!(BidiClass::of(cp), BidiClass::NonspacingMark);
+            assert_ne!(BC::of(cp), BC::NonspacingMark);
+        }
+    }
+}
+
+/// <http://www.unicode.org/reports/tr9/#BN>
+#[test]
+fn test_bidi_bn_against_gen_cat() {
+    for cp in iter_all_chars() {
+        if BC::of(cp) == BC::BoundaryNeutral {
+            assert!(GC::of(cp).is_other());
+        }
+    }
+}
+
+/// <http://www.unicode.org/reports/tr9/#B>
+#[test]
+fn test_bidi_b_against_gen_cat() {
+    for cp in iter_all_chars() {
+        if BC::of(cp) == BC::ParagraphSeparator {
+            assert!(
+                GC::of(cp) == GC::Control ||
+                GC::of(cp) == GC::ParagraphSeparator
+            );
+        }
+    }
+}
+
+/// <http://www.unicode.org/reports/tr9/#S>
+#[test]
+fn test_bidi_s_against_gen_cat() {
+    for cp in iter_all_chars() {
+        if BC::of(cp) == BC::SegmentSeparator {
+            assert!(GC::of(cp) == GC::Control);
+        }
+    }
+}
+
+/// <http://www.unicode.org/reports/tr9/#WS>
+#[test]
+fn test_bidi_ws_against_gen_cat() {
+    for cp in iter_all_chars() {
+        if BC::of(cp) == BC::WhiteSpace {
+            assert!(
+                GC::of(cp) == GC::Control           ||
+                GC::of(cp) == GC::SpaceSeparator    ||
+                GC::of(cp) == GC::LineSeparator
+            );
         }
     }
 }

--- a/unic/ucd/tests/category_tests.rs
+++ b/unic/ucd/tests/category_tests.rs
@@ -12,6 +12,9 @@
 #![cfg(test)]
 
 
+#[macro_use]
+extern crate matches;
+
 extern crate unic_ucd;
 extern crate unic_utils;
 
@@ -20,15 +23,6 @@ use unic_ucd::bidi::BidiClass as BC;
 use unic_ucd::normal::is_combining_mark;
 use unic_ucd::category::GeneralCategory as GC;
 use unic_utils::iter_all_chars;
-
-/// `normal::is_combining_mark` and `GeneralCategory::is_mark()` are expected to return
-/// the same results.
-#[test]
-fn test_gen_cat_against_normal() {
-    for cp in iter_all_chars() {
-        assert_eq!(GC::of(cp).is_mark(), is_combining_mark(cp));
-    }
-}
 
 /// <http://www.unicode.org/reports/tr9/#EN>
 #[test]
@@ -45,10 +39,7 @@ fn test_bidi_en_against_gen_cat() {
 fn test_bidi_es_against_gen_cat() {
     for cp in iter_all_chars() {
         if BC::of(cp) == BC::EuropeanSeparator {
-            assert!(
-                GC::of(cp) == GC::MathSymbol ||
-                GC::of(cp) == GC::DashPunctuation
-            );
+            assert!(matches!(GC::of(cp) , GC::MathSymbol | GC::DashPunctuation));
         }
     }
 }
@@ -60,8 +51,7 @@ fn test_bidi_et_against_gen_cat() {
         if BC::of(cp) == BC::EuropeanTerminator {
             assert!(
                 GC::of(cp).is_symbol()          ||
-                GC::of(cp) == GC::Unassigned    ||
-                GC::of(cp) == GC::OtherPunctuation
+                matches!(GC::of(cp) , GC::Unassigned | GC::OtherPunctuation)
             );
         }
     }
@@ -73,10 +63,7 @@ fn test_bidi_an_against_gen_cat() {
     for cp in iter_all_chars() {
         if BC::of(cp) == BC::ArabicNumber {
             assert!(
-                GC::of(cp) == GC::Format            ||
-                GC::of(cp) == GC::OtherNumber       ||
-                GC::of(cp) == GC::OtherPunctuation  ||
-                GC::of(cp) == GC::DecimalNumber
+                matches!(GC::of(cp) , GC::Format | GC::OtherNumber | GC::OtherPunctuation | GC::DecimalNumber)
             );
         }
     }
@@ -87,11 +74,7 @@ fn test_bidi_an_against_gen_cat() {
 fn test_bidi_cs_against_gen_cat() {
     for cp in iter_all_chars() {
         if BC::of(cp) == BC::CommonSeparator {
-            assert!(
-                GC::of(cp) == GC::OtherPunctuation  ||
-                GC::of(cp) == GC::SpaceSeparator    ||
-                GC::of(cp) == GC::MathSymbol
-            );
+            assert!(matches!(GC::of(cp) , GC::OtherPunctuation | GC::SpaceSeparator | GC::MathSymbol));
         }
     }
 }
@@ -131,10 +114,7 @@ fn test_bidi_bn_against_gen_cat() {
 fn test_bidi_b_against_gen_cat() {
     for cp in iter_all_chars() {
         if BC::of(cp) == BC::ParagraphSeparator {
-            assert!(
-                GC::of(cp) == GC::Control ||
-                GC::of(cp) == GC::ParagraphSeparator
-            );
+            assert!(matches!(GC::of(cp) , GC::Control | GC::ParagraphSeparator));
         }
     }
 }
@@ -144,7 +124,7 @@ fn test_bidi_b_against_gen_cat() {
 fn test_bidi_s_against_gen_cat() {
     for cp in iter_all_chars() {
         if BC::of(cp) == BC::SegmentSeparator {
-            assert!(GC::of(cp) == GC::Control);
+            assert!(matches!(GC::of(cp) , GC::Control));
         }
     }
 }
@@ -154,11 +134,7 @@ fn test_bidi_s_against_gen_cat() {
 fn test_bidi_ws_against_gen_cat() {
     for cp in iter_all_chars() {
         if BC::of(cp) == BC::WhiteSpace {
-            assert!(
-                GC::of(cp) == GC::Control           ||
-                GC::of(cp) == GC::SpaceSeparator    ||
-                GC::of(cp) == GC::LineSeparator
-            );
+            assert!(matches!(GC::of(cp) , GC::Control | GC::SpaceSeparator | GC::LineSeparator));
         }
     }
 }


### PR DESCRIPTION
This PR is my first attempt at closing #43. I have added 10 tests to the `category_tests.rs` test file.

I also corrected a typo in `category.rs` which was causing one of my tests to fail. 

Any feedback would be appreciated and I am happy to make changes.

UPDATE:
I removed my test for Bidi types OtherNeutral since from the [table of Bidi character types](http://www.unicode.org/reports/tr9/#Table_Bidirectional_Character_Types) this includes the General_Category types:

> All other characters, including OBJECT REPLACEMENT CHARACTER

Which is too general for a test - do you agree?