### PR TITLE
[ucd/category] Add coverage_tests for major category methods

### DIFF
--- a/unic/ucd/category/Cargo.toml
+++ b/unic/ucd/category/Cargo.toml
@@ -16,4 +16,5 @@ travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
 unic-ucd-core = { path = "../core/", version = "0.4.0" }
+unic-utils = { path = "../../utils/", version = "0.4.0" }
 matches = "0.1.6"

--- a/unic/ucd/category/tests/coverage_tests.rs
+++ b/unic/ucd/category/tests/coverage_tests.rs
@@ -1,0 +1,114 @@
+// Copyright 2017 The UNIC Project Developers.
+//
+// See the COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+extern crate unic_ucd_category;
+extern crate unic_utils;
+
+
+use unic_ucd_category::GeneralCategory;
+use unic_utils::iter_all_chars;
+
+
+/// Every char falls in exactly one of the major categories; with the exception of `CasedLetter`,
+/// when it's also a `Letter`.
+#[test]
+fn test_general_category_major_groups() {
+    for cp in iter_all_chars() {
+        let gc = GeneralCategory::of(cp);
+
+        if gc.is_cased_letter() {
+            assert!(
+                gc.is_letter() &&
+                !gc.is_mark() &&
+                !gc.is_number() &&
+                !gc.is_punctuation() &&
+                !gc.is_symbol() &&
+                !gc.is_separator() &&
+                !gc.is_other(),
+                "cp: U+{:04X}, GC: `{:?}`",
+                cp as u32,
+                gc
+            );
+
+        } else if gc.is_letter() {
+            assert!(
+                !gc.is_mark() &&
+                !gc.is_number() &&
+                !gc.is_punctuation() &&
+                !gc.is_symbol() &&
+                !gc.is_separator() &&
+                !gc.is_other(),
+                "cp: U+{:04X}, GC: `{:?}`",
+                cp as u32,
+                gc
+            );
+
+        } else if gc.is_mark() {
+            assert!(
+                !gc.is_number() &&
+                !gc.is_punctuation() &&
+                !gc.is_symbol() &&
+                !gc.is_separator() &&
+                !gc.is_other(),
+                "cp: U+{:04X}, GC: `{:?}`",
+                cp as u32,
+                gc
+            );
+
+        } else if gc.is_number() {
+            assert!(
+                !gc.is_punctuation() &&
+                !gc.is_symbol() &&
+                !gc.is_separator() &&
+                !gc.is_other(),
+                "cp: U+{:04X}, GC: `{:?}`",
+                cp as u32,
+                gc
+            );
+
+        } else if gc.is_punctuation() {
+            assert!(
+                !gc.is_symbol() &&
+                !gc.is_separator() &&
+                !gc.is_other(),
+                "cp: U+{:04X}, GC: `{:?}`",
+                cp as u32,
+                gc
+            );
+
+        } else if gc.is_symbol() {
+            assert!(
+                !gc.is_separator() &&
+                !gc.is_other(),
+                "cp: U+{:04X}, GC: `{:?}`",
+                cp as u32,
+                gc
+            );
+
+        } else if gc.is_separator() {
+            assert!(
+                !gc.is_other(),
+                "cp: U+{:04X}, GC: `{:?}`",
+                cp as u32,
+                gc
+            );
+
+        } else {
+            assert!(
+                gc.is_other(),
+                "cp: U+{:04X}, GC: `{:?}`",
+                cp as u32,
+                gc
+            );
+
+        }
+    }
+}


### PR DESCRIPTION
The coverage test makes sure there's no overlap between major categories, except the case of `Cased_Letter` and `Letter`.

The test can catch bugs like the one fixed in <https://github.com/behnam/rust-unic/pull/60>.