### PR TITLE
[ucd/category] Add all_values() static fn

### DIFF
--- a/unic/ucd/category/Cargo.toml
+++ b/unic/ucd/category/Cargo.toml
@@ -16,5 +16,4 @@ travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
 unic-ucd-core = { path = "../core/", version = "0.4.0" }
-unic-utils = { path = "../../utils/", version = "0.4.0" }
 matches = "0.1.6"

--- a/unic/ucd/category/src/category.rs
+++ b/unic/ucd/category/src/category.rs
@@ -118,9 +118,49 @@ const GENERAL_CATEGORY_TABLE: &'static [(char, char, GeneralCategory)] =
     include!("tables/general_category.rsv");
 
 impl GeneralCategory {
-    /// Find the GeneralCategory of a single char.
+    /// Find the `GeneralCategory` of a single char.
     pub fn of(ch: char) -> GeneralCategory {
         bsearch_range_value_table(ch, GENERAL_CATEGORY_TABLE)
+    }
+
+    /// Exhaustive list of all `GeneralCategory` property values.
+    ///
+    /// Ref: <http://unicode.org/reports/tr44/#General_Category_Values>
+    pub fn all_values() -> &'static [GeneralCategory] {
+        use GeneralCategory::*;
+        const ALL_VALUES: &[GeneralCategory] = &[
+            UppercaseLetter,
+            LowercaseLetter,
+            TitlecaseLetter,
+            ModifierLetter,
+            OtherLetter,
+            NonspacingMark,
+            SpacingMark,
+            EnclosingMark,
+            DecimalNumber,
+            LetterNumber,
+            OtherNumber,
+            ConnectorPunctuation,
+            DashPunctuation,
+            OpenPunctuation,
+            ClosePunctuation,
+            InitialPunctuation,
+            FinalPunctuation,
+            OtherPunctuation,
+            MathSymbol,
+            CurrencySymbol,
+            ModifierSymbol,
+            OtherSymbol,
+            SpaceSeparator,
+            LineSeparator,
+            ParagraphSeparator,
+            Control,
+            Format,
+            Surrogate,
+            PrivateUse,
+            Unassigned,
+        ];
+        ALL_VALUES
     }
 }
 

--- a/unic/ucd/category/tests/coverage_tests.rs
+++ b/unic/ucd/category/tests/coverage_tests.rs
@@ -10,20 +10,16 @@
 
 
 extern crate unic_ucd_category;
-extern crate unic_utils;
 
 
 use unic_ucd_category::GeneralCategory;
-use unic_utils::iter_all_chars;
 
 
 /// Every char falls in exactly one of the major categories; with the exception of `CasedLetter`,
 /// when it's also a `Letter`.
 #[test]
 fn test_general_category_major_groups() {
-    for cp in iter_all_chars() {
-        let gc = GeneralCategory::of(cp);
-
+    for gc in GeneralCategory::all_values() {
         if gc.is_cased_letter() {
             assert!(
                 gc.is_letter() &&
@@ -33,8 +29,7 @@ fn test_general_category_major_groups() {
                 !gc.is_symbol() &&
                 !gc.is_separator() &&
                 !gc.is_other(),
-                "cp: U+{:04X}, GC: `{:?}`",
-                cp as u32,
+                "GC: `{:?}`",
                 gc
             );
 
@@ -46,8 +41,7 @@ fn test_general_category_major_groups() {
                 !gc.is_symbol() &&
                 !gc.is_separator() &&
                 !gc.is_other(),
-                "cp: U+{:04X}, GC: `{:?}`",
-                cp as u32,
+                "GC: `{:?}`",
                 gc
             );
 
@@ -58,8 +52,7 @@ fn test_general_category_major_groups() {
                 !gc.is_symbol() &&
                 !gc.is_separator() &&
                 !gc.is_other(),
-                "cp: U+{:04X}, GC: `{:?}`",
-                cp as u32,
+                "GC: `{:?}`",
                 gc
             );
 
@@ -69,8 +62,7 @@ fn test_general_category_major_groups() {
                 !gc.is_symbol() &&
                 !gc.is_separator() &&
                 !gc.is_other(),
-                "cp: U+{:04X}, GC: `{:?}`",
-                cp as u32,
+                "GC: `{:?}`",
                 gc
             );
 
@@ -79,8 +71,7 @@ fn test_general_category_major_groups() {
                 !gc.is_symbol() &&
                 !gc.is_separator() &&
                 !gc.is_other(),
-                "cp: U+{:04X}, GC: `{:?}`",
-                cp as u32,
+                "GC: `{:?}`",
                 gc
             );
 
@@ -88,24 +79,21 @@ fn test_general_category_major_groups() {
             assert!(
                 !gc.is_separator() &&
                 !gc.is_other(),
-                "cp: U+{:04X}, GC: `{:?}`",
-                cp as u32,
+                "GC: `{:?}`",
                 gc
             );
 
         } else if gc.is_separator() {
             assert!(
                 !gc.is_other(),
-                "cp: U+{:04X}, GC: `{:?}`",
-                cp as u32,
+                "GC: `{:?}`",
                 gc
             );
 
         } else {
             assert!(
                 gc.is_other(),
-                "cp: U+{:04X}, GC: `{:?}`",
-                cp as u32,
+                "GC: `{:?}`",
                 gc
             );
 


### PR DESCRIPTION
The `all_values()` static function is a new API for character
properties implemented as *flat* `enum` types in Rust, like some of
Unicode properties of type *Catalog* or *Enumeration*, to return an
exhaustive list of all possible values.

The function is useful mainly in writing integration tests, but since is
efficient in implementation, can be used in application logic, as well.

The current list is manually created and maintained. With migration to
`char_property` macros, the list will be auto-generated. (Possibly
stored in a private module and only exposed via `all_values()` API.)

See <https://github.com/behnam/rust-unic/issues/66>