### PR TITLE
Return a DoubleEndedIterator from iter_all_chars

### DIFF
--- a/unic/utils/src/codepoints.rs
+++ b/unic/utils/src/codepoints.rs
@@ -34,108 +34,23 @@ pub const CODEPOINTS_RANGE: Range<u32> = 0x0..(0x10_FFFF + 1);
 /// Reference: <http://unicode.org/glossary/#surrogate_code_point>
 pub const SURROGATE_RANGE: Range<u32> = 0xD800..(0xDFFF + 1);
 
-/// Check a code-point against `SURROGATE_CODEPOINTS_RANGE`.
 #[inline]
-pub fn iter_all_chars() -> Box<Iterator<Item = char>> {
-    Box::new(CharIterator::new())
-}
-
-#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
-/// An iterator over all `char`.
-pub struct CharIterator {
-    /// The codepoint of the smallest uniterated codepoint.
-    ///
-    /// If greater than or equal to `end`, iteration is finished.
-    ///
-    /// # Safety
-    ///
-    /// Must be a valid, non-surrogate codepoint.
-    current: u32,
-
-    /// The codepoint one greater than the largest uniterated codepoint.
-    ///
-    /// If less than or equal to `current`, iteration is finished.
-    ///
-    /// # Safety
-    ///
-    /// Must be a valid, non-surrogate codepoint.
-    end: u32,
-}
-
-impl CharIterator {
-    fn new() -> CharIterator {
-        CharIterator {
-            current: CODEPOINTS_RANGE.start,
-            end: CODEPOINTS_RANGE.end,
-        }
-    }
-
-    // cannot be is_empty because usages conflict the unstable is_empty
-    fn is_finished(&self) -> bool {
-        self.current >= self.end
-    }
-}
-
-impl Default for CharIterator {
-    fn default() -> CharIterator {
-        CharIterator::new()
-    }
-}
-
-impl Iterator for CharIterator {
-    type Item = char;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.is_finished() {
-            return None;
-        }
-
-        let next = unsafe { char::from_u32_unchecked(self.current) };
-
-        self.current += 1;
-        if self.current == SURROGATE_RANGE.start {
-            self.current = SURROGATE_RANGE.end
-        }
-
-        Some(next)
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.len();
-        (len, Some(len))
-    }
-}
-
-impl DoubleEndedIterator for CharIterator {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if self.is_finished() {
-            return None;
-        }
-
-        if self.end == SURROGATE_RANGE.end {
-            self.end = SURROGATE_RANGE.start;
-        }
-        self.end -= 1;
-
-        let next = unsafe { char::from_u32_unchecked(self.end) };
-
-        Some(next)
-    }
-}
-
-impl ExactSizeIterator for CharIterator {
-    fn len(&self) -> usize {
-        let mut remaining_codepoints = self.end - self.current;
-        if self.current < SURROGATE_RANGE.start && self.end >= SURROGATE_RANGE.end {
-            remaining_codepoints -= SURROGATE_RANGE.len() as u32;
-        }
-        remaining_codepoints as usize
-    }
+#[allow(unsafe_code)]
+/// Create an iterator over all characters
+pub fn iter_all_chars() -> Box<DoubleEndedIterator<Item = char>> {
+    Box::new(
+        (CODEPOINTS_RANGE.start..SURROGATE_RANGE.start)
+            .chain(SURROGATE_RANGE.end..CODEPOINTS_RANGE.end)
+            .map(|codepoint| {
+                debug_assert!(char::from_u32(codepoint).is_some());
+                unsafe { char::from_u32_unchecked(codepoint) }
+            }),
+    )
 }
 
 #[cfg(test)]
 mod test {
-    use super::{iter_all_chars, CharIterator};
+    use super::iter_all_chars;
     use std::{char, fmt};
 
     fn evident_iter_all_chars() -> Box<Iterator<Item = char>> {
@@ -165,58 +80,12 @@ mod test {
 
     #[test]
     fn reverse_iteration_works() {
-        let ours = CharIterator::new().rev();
+        let ours = iter_all_chars().rev();
         let evident = evident_iter_all_chars()
             .collect::<Vec<_>>()
             .into_iter()
             .rev();
 
         assert_equal_contents(ours, evident);
-    }
-
-    #[test]
-    fn is_exact_size_hint_forwards() {
-        let mut iter = CharIterator::new();
-        let mut len = iter.len();
-        let (mut lower_bound, higher_bound) = iter.size_hint();
-
-        assert_eq!(Some(lower_bound), higher_bound);
-        let mut higher_bound = higher_bound.unwrap();
-
-        while let Some(_) = iter.next() {
-            len -= 1;
-            lower_bound -= 1;
-            higher_bound -= 1;
-
-            assert_eq!(len, iter.len());
-            assert_eq!((lower_bound, Some(higher_bound)), iter.size_hint());
-        }
-
-        assert_eq!(len, 0);
-        assert_eq!(lower_bound, 0);
-        assert_eq!(higher_bound, 0);
-    }
-
-    #[test]
-    fn is_exact_size_hint_backwards() {
-        let mut iter = CharIterator::new();
-        let mut len = iter.len();
-        let (mut lower_bound, higher_bound) = iter.size_hint();
-
-        assert_eq!(Some(lower_bound), higher_bound);
-        let mut higher_bound = higher_bound.unwrap();
-
-        while let Some(_) = iter.next_back() {
-            len -= 1;
-            lower_bound -= 1;
-            higher_bound -= 1;
-
-            assert_eq!(len, iter.len());
-            assert_eq!((lower_bound, Some(higher_bound)), iter.size_hint());
-        }
-
-        assert_eq!(len, 0);
-        assert_eq!(lower_bound, 0);
-        assert_eq!(higher_bound, 0);
     }
 }

--- a/unic/utils/src/codepoints.rs
+++ b/unic/utils/src/codepoints.rs
@@ -20,7 +20,7 @@
 //! * [**Unicode Code Point**](http://unicode.org/glossary/#code_point)
 //! * [**Unicode Scalar Value**](http://unicode.org/glossary/#unicode_scalar_value)
 
-use std::char::from_u32;
+use std::char;
 use std::ops::Range;
 
 
@@ -29,19 +29,194 @@ use std::ops::Range;
 /// Reference: <http://unicode.org/glossary/#code_point>
 pub const CODEPOINTS_RANGE: Range<u32> = 0x0..(0x10_FFFF + 1);
 
-/// Range of Unicde Scalar Values.
+/// Range of Surrogate Code Points.
 ///
-/// Reference: <http://unicode.org/glossary/#unicode_scalar_value>
-const SCALAR_VALUE_RANGE_1: Range<u32> = 0x0..0xD800;
-const SCALAR_VALUE_RANGE_2: Range<u32> = (0xDFFF + 1)..(0x10_FFFF + 1);
+/// Reference: <http://unicode.org/glossary/#surrogate_code_point>
+pub const SURROGATE_RANGE: Range<u32> = 0xD800..(0xDFFF + 1);
 
 /// Check a code-point against `SURROGATE_CODEPOINTS_RANGE`.
 #[inline]
 pub fn iter_all_chars() -> Box<Iterator<Item = char>> {
-    Box::new(
-        // TODO: maybe use char::from_u32_unchecked()
-        SCALAR_VALUE_RANGE_1
-            .chain(SCALAR_VALUE_RANGE_2)
-            .filter_map(from_u32),
-    )
+    Box::new(CharIterator::new())
+}
+
+#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
+/// An iterator over all `char`.
+pub struct CharIterator {
+    /// The codepoint of the smallest uniterated codepoint.
+    ///
+    /// If greater than or equal to `end`, iteration is finished.
+    ///
+    /// # Safety
+    ///
+    /// Must be a valid, non-surrogate codepoint.
+    current: u32,
+
+    /// The codepoint one greater than the largest uniterated codepoint.
+    ///
+    /// If less than or equal to `current`, iteration is finished.
+    ///
+    /// # Safety
+    ///
+    /// Must be a valid, non-surrogate codepoint.
+    end: u32,
+}
+
+impl CharIterator {
+    fn new() -> CharIterator {
+        CharIterator {
+            current: CODEPOINTS_RANGE.start,
+            end: CODEPOINTS_RANGE.end,
+        }
+    }
+
+    // cannot be is_empty because usages conflict the unstable is_empty
+    fn is_finished(&self) -> bool {
+        self.current >= self.end
+    }
+}
+
+impl Default for CharIterator {
+    fn default() -> CharIterator {
+        CharIterator::new()
+    }
+}
+
+impl Iterator for CharIterator {
+    type Item = char;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.is_finished() {
+            return None;
+        }
+
+        let next = unsafe { char::from_u32_unchecked(self.current) };
+
+        self.current += 1;
+        if self.current == SURROGATE_RANGE.start {
+            self.current = SURROGATE_RANGE.end
+        }
+
+        Some(next)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+impl DoubleEndedIterator for CharIterator {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.is_finished() {
+            return None;
+        }
+
+        if self.end == SURROGATE_RANGE.end {
+            self.end = SURROGATE_RANGE.start;
+        }
+        self.end -= 1;
+
+        let next = unsafe { char::from_u32_unchecked(self.end) };
+
+        Some(next)
+    }
+}
+
+impl ExactSizeIterator for CharIterator {
+    fn len(&self) -> usize {
+        let mut remaining_codepoints = self.end - self.current;
+        if self.current < SURROGATE_RANGE.start && self.end >= SURROGATE_RANGE.end {
+            remaining_codepoints -= SURROGATE_RANGE.len() as u32;
+        }
+        remaining_codepoints as usize
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{iter_all_chars, CharIterator};
+    use std::{char, fmt};
+
+    fn evident_iter_all_chars() -> Box<Iterator<Item = char>> {
+        Box::new((0..char::MAX as u32 + 1).filter_map(char::from_u32))
+    }
+
+    fn assert_equal_contents<I, J, Item>(lhs: I, rhs: J)
+    where
+        I: Iterator<Item = Item>,
+        J: Iterator<Item = Item>,
+        Item: PartialEq + fmt::Debug,
+    {
+        let mut rhs = rhs.fuse();
+        for item in lhs {
+            assert_eq!(Some(item), rhs.next());
+        }
+        assert_eq!(rhs.count(), 0);
+    }
+
+    #[test]
+    fn iter_all_chars_does_so() {
+        let ours = iter_all_chars();
+        let evident = evident_iter_all_chars();
+
+        assert_equal_contents(ours, evident);
+    }
+
+    #[test]
+    fn reverse_iteration_works() {
+        let ours = CharIterator::new().rev();
+        let evident = evident_iter_all_chars()
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev();
+
+        assert_equal_contents(ours, evident);
+    }
+
+    #[test]
+    fn is_exact_size_hint_forwards() {
+        let mut iter = CharIterator::new();
+        let mut len = iter.len();
+        let (mut lower_bound, higher_bound) = iter.size_hint();
+
+        assert_eq!(Some(lower_bound), higher_bound);
+        let mut higher_bound = higher_bound.unwrap();
+
+        while let Some(_) = iter.next() {
+            len -= 1;
+            lower_bound -= 1;
+            higher_bound -= 1;
+
+            assert_eq!(len, iter.len());
+            assert_eq!((lower_bound, Some(higher_bound)), iter.size_hint());
+        }
+
+        assert_eq!(len, 0);
+        assert_eq!(lower_bound, 0);
+        assert_eq!(higher_bound, 0);
+    }
+
+    #[test]
+    fn is_exact_size_hint_backwards() {
+        let mut iter = CharIterator::new();
+        let mut len = iter.len();
+        let (mut lower_bound, higher_bound) = iter.size_hint();
+
+        assert_eq!(Some(lower_bound), higher_bound);
+        let mut higher_bound = higher_bound.unwrap();
+
+        while let Some(_) = iter.next_back() {
+            len -= 1;
+            lower_bound -= 1;
+            higher_bound -= 1;
+
+            assert_eq!(len, iter.len());
+            assert_eq!((lower_bound, Some(higher_bound)), iter.size_hint());
+        }
+
+        assert_eq!(len, 0);
+        assert_eq!(lower_bound, 0);
+        assert_eq!(higher_bound, 0);
+    }
 }

--- a/unic/utils/src/lib.rs
+++ b/unic/utils/src/lib.rs
@@ -10,6 +10,7 @@
 
 
 #![forbid(missing_docs)]
+#![deny(unsafe_code)]
 
 //! # UNIC — Utilities
 //!

--- a/unic/utils/src/lib.rs
+++ b/unic/utils/src/lib.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 
-#![forbid(unsafe_code, missing_docs)]
+#![forbid(missing_docs)]
 
 //! # UNIC — Utilities
 //!


### PR DESCRIPTION
This PR originally proposed a more drastic change. See c061708576c5989f20820a449a05e2023ed91887. It now takes the more conservative change proposed as an alternative in the original text. See the original proposal text below.

<hr/>

This is mostly to show what the iterator would look like. Having the custom iterator comes with the benefits of having a custom iterator that implements `ExactSizeIterator` and `DoubleEndedIterator`.

Note that when `impl DoubleEndedIterator` is possible, changing `iter_all_chars` to the following gets a `DoubleEndedIterator` without a custom type:

```rust
pub fn iter_all_chars() -> impl DoubleEndedIterator<Item=char> {
    (CODEPOINTS_RANGE.start..SURROGATE_RANGE.start)
        .chain(SURROGATE_RANGE.end..CODEPOINTS_RANGE.end)
        .map(|codepoint| {
            debug_assert!(char::from_u32(codepoint).is_some());
            unsafe { char::from_u32_unchecked(codepoint) }
        })
}
```

I suspect that the solution of chaining together the two scalar value ranges is going to be marginally faster than the solution in this PR which has to check every time whether or not we are about to step into the surrogate range to avoid returning invalid characters. This would need benchmarking, though, and is heavily dependent on how the `Chain` iterator moves from one iterator to the next.

Even if this PR is not taken as is, I would suggest revising `iter_all_chars` to the `impl Trait` version above in `Box<Trait>` form, as we can then provide reverse iteration at no cost.

This PR leaves `iter_all_chars` returning `Box<Iterator>` in order to not break the API, even though it would now be possible and not too problematic to return a stack value. It may be worthwhile to also, whether this proposal is accepted or not, wrap the current iterator stack into a newtype that impls `Iterator` and any other relevant iterator traits, such that the returned iterator can be stack allocated rather than boxed.

This PR also cleans up some of the comments which had gotten slightly out of date. Personally, I also find the style shown in this PR of using the `SURROGATE_RANGE` and `CODEPOINTS_RANGE` to simulate `SCALAR_VALUE_RANGE_1` and `SCALAR_VALUE_RANGE_2` conveys intent more clearly. See above for what the current chaining call looks like with these ranges.

Also, one other small negative of this PR: it quadruples the length of this file 🙃 (and removes the `#[deny(unsafe)]` from the utils crate).