### PR TITLE
[utils] Consolidate table bsearching

### DIFF
--- a/unic/ucd/age/Cargo.toml
+++ b/unic/ucd/age/Cargo.toml
@@ -16,6 +16,4 @@ travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
 unic-ucd-core = { path = "../core/", version = "0.5.0" }
-
-[dev-dependencies]
 unic-utils = { path = "../../utils", version = "0.5.0" }

--- a/unic/ucd/age/src/age.rs
+++ b/unic/ucd/age/src/age.rs
@@ -11,7 +11,7 @@
 
 use std::fmt;
 
-use unic_utils::CharBsearchTable;
+use unic_utils::CharDataTable;
 
 pub use unic_ucd_core::UnicodeVersion;
 
@@ -48,7 +48,7 @@ pub const AGE_TABLE: &'static [(char, char, Age)] = include!("tables/age_values.
 impl Age {
     /// Find the character *Age* property value.
     pub fn of(ch: char) -> Age {
-        *AGE_TABLE.binary_search_or(ch, &Age::Unassigned)
+        *AGE_TABLE.find_or(ch, &Age::Unassigned)
     }
 
     /// Return `Some(unicode_version)`, if code point is assigned (as character or noncharacter,

--- a/unic/ucd/age/src/age.rs
+++ b/unic/ucd/age/src/age.rs
@@ -9,8 +9,9 @@
 // except according to those terms.
 
 
-use std::cmp::Ordering;
 use std::fmt;
+
+use unic_utils::CharBsearchTable;
 
 pub use unic_ucd_core::UnicodeVersion;
 
@@ -47,7 +48,7 @@ pub const AGE_TABLE: &'static [(char, char, Age)] = include!("tables/age_values.
 impl Age {
     /// Find the character *Age* property value.
     pub fn of(ch: char) -> Age {
-        bsearch_range_value_table(ch, AGE_TABLE)
+        *AGE_TABLE.binary_search_or(ch, &Age::Unassigned)
     }
 
     /// Return `Some(unicode_version)`, if code point is assigned (as character or noncharacter,
@@ -86,25 +87,6 @@ impl Age {
             Age::Assigned(uni_ver) => format!("Assigned in Unicode {}", uni_ver).to_owned(),
             Age::Unassigned => "Unassigned".to_owned(),
         }
-    }
-}
-
-// TODO: Generic'ize and move to `unic-ucd-utils`
-// TODO: Optimize: put Unassigned ranges into the table, then only store (start, age) instead of
-// (start, end, age)
-fn bsearch_range_value_table(ch: char, r: &'static [(char, char, Age)]) -> Age {
-    match r.binary_search_by(|&(lo, hi, _)| if lo <= ch && ch <= hi {
-        Ordering::Equal
-    } else if hi < ch {
-        Ordering::Less
-    } else {
-        Ordering::Greater
-    }) {
-        Ok(idx) => {
-            let (_, _, cat) = r[idx];
-            cat
-        }
-        Err(_) => Unassigned,
     }
 }
 

--- a/unic/ucd/age/src/lib.rs
+++ b/unic/ucd/age/src/lib.rs
@@ -23,6 +23,7 @@
 //! * <http://www.unicode.org/reports/tr44/#Character_Age>
 
 extern crate unic_ucd_core;
+extern crate unic_utils;
 
 
 mod age;

--- a/unic/ucd/bidi/Cargo.toml
+++ b/unic/ucd/bidi/Cargo.toml
@@ -16,3 +16,4 @@ travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
 unic-ucd-core = { path = "../core/", version = "0.5.0" }
+unic-utils = { path = "../../utils/", version = "0.5.0" }

--- a/unic/ucd/bidi/src/bidi_class.rs
+++ b/unic/ucd/bidi/src/bidi_class.rs
@@ -11,7 +11,7 @@
 
 use std::fmt;
 
-use unic_utils::CharBsearchTable;
+use unic_utils::CharDataTable;
 
 /// Represents the Unicode character
 /// [*Bidi_Class*](http://www.unicode.org/reports/tr44/#Bidi_Class) property, also known as the
@@ -111,7 +111,7 @@ impl BidiClass {
     pub fn of(ch: char) -> BidiClass {
         // UCD/extracted/DerivedBidiClass.txt: "All code points not explicitly listed
         // for Bidi_Class have the value Left_To_Right (L)."
-        *BIDI_CLASS_TABLE.binary_search_or(ch, &L)
+        *BIDI_CLASS_TABLE.find_or(ch, &L)
     }
 
     /// Abbreviated name of the *Bidi_Class* property value.

--- a/unic/ucd/bidi/src/lib.rs
+++ b/unic/ucd/bidi/src/lib.rs
@@ -20,6 +20,7 @@
 //! Accessor for `Bidi_Class` property from Unicode Character Database (UCD)
 
 extern crate unic_ucd_core;
+extern crate unic_utils;
 
 
 /// Unicode *Bidi_Class* Character Property.

--- a/unic/ucd/category/Cargo.toml
+++ b/unic/ucd/category/Cargo.toml
@@ -16,4 +16,5 @@ travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
 unic-ucd-core = { path = "../core/", version = "0.5.0" }
+unic-utils = { path = "../../utils/", version = "0.5.0" }
 matches = "0.1"

--- a/unic/ucd/category/src/category.rs
+++ b/unic/ucd/category/src/category.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::cmp::Ordering;
+use unic_utils::CharBsearchTable;
 
 /// Represents the Unicode Character
 /// [*General_Category*](http://unicode.org/reports/tr44/#General_Category) property.
@@ -120,7 +120,7 @@ const GENERAL_CATEGORY_TABLE: &'static [(char, char, GeneralCategory)] =
 impl GeneralCategory {
     /// Find the `GeneralCategory` of a single char.
     pub fn of(ch: char) -> GeneralCategory {
-        bsearch_range_value_table(ch, GENERAL_CATEGORY_TABLE)
+        *GENERAL_CATEGORY_TABLE.binary_search_or(ch, &GeneralCategory::Unassigned)
     }
 
     /// Exhaustive list of all `GeneralCategory` property values.
@@ -203,25 +203,6 @@ impl GeneralCategory {
     /// `Cc` | `Cf` | `Cs` | `Co` | `Cn`  (Short form: `C`)
     pub fn is_other(&self) -> bool {
         matches!(*self, Cc | Cf | Cs | Co | Cn)
-    }
-}
-
-fn bsearch_range_value_table(
-    c: char,
-    r: &'static [(char, char, GeneralCategory)],
-) -> GeneralCategory {
-    match r.binary_search_by(|&(lo, hi, _)| if lo <= c && c <= hi {
-        Ordering::Equal
-    } else if hi < c {
-        Ordering::Less
-    } else {
-        Ordering::Greater
-    }) {
-        Ok(idx) => {
-            let (_, _, category) = r[idx];
-            category
-        }
-        Err(_) => GeneralCategory::Unassigned,
     }
 }
 

--- a/unic/ucd/category/src/category.rs
+++ b/unic/ucd/category/src/category.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use unic_utils::CharBsearchTable;
+use unic_utils::CharDataTable;
 
 /// Represents the Unicode Character
 /// [*General_Category*](http://unicode.org/reports/tr44/#General_Category) property.
@@ -120,7 +120,7 @@ const GENERAL_CATEGORY_TABLE: &'static [(char, char, GeneralCategory)] =
 impl GeneralCategory {
     /// Find the `GeneralCategory` of a single char.
     pub fn of(ch: char) -> GeneralCategory {
-        *GENERAL_CATEGORY_TABLE.binary_search_or(ch, &GeneralCategory::Unassigned)
+        *GENERAL_CATEGORY_TABLE.find_or(ch, &GeneralCategory::Unassigned)
     }
 
     /// Exhaustive list of all `GeneralCategory` property values.

--- a/unic/ucd/category/src/lib.rs
+++ b/unic/ucd/category/src/lib.rs
@@ -39,6 +39,7 @@
 #[macro_use]
 extern crate matches;
 extern crate unic_ucd_core;
+extern crate unic_utils;
 
 mod category;
 

--- a/unic/ucd/normal/Cargo.toml
+++ b/unic/ucd/normal/Cargo.toml
@@ -20,6 +20,7 @@ travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 [dependencies]
 unic-ucd-core = { path = "../core/", version = "0.5.0" }
 unic-ucd-category = { path = "../category/", version = "0.5.0", optional = true }
+unic-utils = { path = "../../utils/", version = "0.5.0" }
 
 [dev-dependencies]
 unic-utils = { path = "../../utils", version = "0.5.0" }

--- a/unic/ucd/normal/src/canonical_combining_class.rs
+++ b/unic/ucd/normal/src/canonical_combining_class.rs
@@ -15,7 +15,7 @@
 //! Reference: <http://unicode.org/reports/tr44/#Canonical_Combining_Class_Values>
 
 
-use std::cmp::Ordering;
+use unic_utils::CharBsearchTable;
 
 
 /// Represents *Canonical_Combining_Class* property of a Unicode character.
@@ -89,7 +89,7 @@ const CANONICAL_COMBINING_CLASS_VALUES: &'static [(char, char, CanonicalCombinin
 impl CanonicalCombiningClass {
     /// Find the character *Canonical_Combining_Class* property value.
     pub fn of(ch: char) -> CanonicalCombiningClass {
-        bsearch_range_value_table(ch, CANONICAL_COMBINING_CLASS_VALUES)
+        *CANONICAL_COMBINING_CLASS_VALUES.binary_search_or(ch, &CanonicalCombiningClass(0))
     }
 }
 
@@ -108,26 +108,6 @@ impl CanonicalCombiningClass {
     /// If the *ccc* any value other than `Not_Reordered` (`0`).
     pub fn is_reordered(&self) -> bool {
         self.0 != 0
-    }
-}
-
-
-fn bsearch_range_value_table(
-    c: char,
-    r: &'static [(char, char, CanonicalCombiningClass)],
-) -> CanonicalCombiningClass {
-    match r.binary_search_by(|&(lo, hi, _)| if lo <= c && c <= hi {
-        Ordering::Equal
-    } else if hi < c {
-        Ordering::Less
-    } else {
-        Ordering::Greater
-    }) {
-        Ok(idx) => {
-            let (_, _, result) = r[idx];
-            result
-        }
-        Err(_) => CanonicalCombiningClass(0),
     }
 }
 

--- a/unic/ucd/normal/src/canonical_combining_class.rs
+++ b/unic/ucd/normal/src/canonical_combining_class.rs
@@ -15,7 +15,7 @@
 //! Reference: <http://unicode.org/reports/tr44/#Canonical_Combining_Class_Values>
 
 
-use unic_utils::CharBsearchTable;
+use unic_utils::CharDataTable;
 
 
 /// Represents *Canonical_Combining_Class* property of a Unicode character.
@@ -89,7 +89,7 @@ const CANONICAL_COMBINING_CLASS_VALUES: &'static [(char, char, CanonicalCombinin
 impl CanonicalCombiningClass {
     /// Find the character *Canonical_Combining_Class* property value.
     pub fn of(ch: char) -> CanonicalCombiningClass {
-        *CANONICAL_COMBINING_CLASS_VALUES.binary_search_or(ch, &CanonicalCombiningClass(0))
+        *CANONICAL_COMBINING_CLASS_VALUES.find_or(ch, &CanonicalCombiningClass(0))
     }
 }
 

--- a/unic/ucd/normal/src/composition.rs
+++ b/unic/ucd/normal/src/composition.rs
@@ -10,7 +10,7 @@
 // except according to those terms.
 
 
-use std::cmp::Ordering;
+use unic_utils::CharBsearchTable;
 
 
 pub struct Slice {
@@ -23,21 +23,11 @@ fn bsearch_lookup_table<T>(
     r: &'static [(char, Slice)],
     chars_table: &'static [T],
 ) -> Option<&'static [T]> {
-    match r.binary_search_by(|&(val, _)| if c == val {
-        Ordering::Equal
-    } else if val < c {
-        Ordering::Less
-    } else {
-        Ordering::Greater
-    }) {
-        Ok(idx) => {
-            let slice = &r[idx].1;
-            let offset = slice.offset as usize;
-            let length = slice.length as usize;
-            Some(&chars_table[offset..(offset + length)])
-        }
-        Err(_) => None,
-    }
+    r.find(c).map(|slice| {
+        let offset = slice.offset as usize;
+        let length = slice.length as usize;
+        &chars_table[offset..(offset + length)]
+    })
 }
 
 // == Canonical Composition (C) ==

--- a/unic/ucd/normal/src/composition.rs
+++ b/unic/ucd/normal/src/composition.rs
@@ -10,7 +10,7 @@
 // except according to those terms.
 
 
-use unic_utils::CharBsearchTable;
+use unic_utils::CharDataTable;
 
 
 pub struct Slice {

--- a/unic/ucd/normal/src/decomposition_type.rs
+++ b/unic/ucd/normal/src/decomposition_type.rs
@@ -12,7 +12,7 @@
 
 //! Accessor for *Decomposition_Type* (dt) property
 
-use std::cmp::Ordering;
+use unic_utils::CharBsearchTable;
 
 use composition::canonical_decomposition;
 use hangul;
@@ -60,26 +60,7 @@ impl DecompositionType {
         if hangul::is_syllable(ch) || canonical_decomposition(ch).is_some() {
             return Some(Canonical);
         }
-        bsearch_range_value_table(ch, COMPATIBILITY_DECOMPOSITION_TYPE_TABLE)
-    }
-}
-
-fn bsearch_range_value_table(
-    c: char,
-    r: &'static [(char, char, DecompositionType)],
-) -> Option<DecompositionType> {
-    match r.binary_search_by(|&(lo, hi, _)| if lo <= c && c <= hi {
-        Ordering::Equal
-    } else if hi < c {
-        Ordering::Less
-    } else {
-        Ordering::Greater
-    }) {
-        Ok(idx) => {
-            let (_, _, dt) = r[idx];
-            Some(dt)
-        }
-        Err(_) => Option::None,
+        COMPATIBILITY_DECOMPOSITION_TYPE_TABLE.find(ch).cloned()
     }
 }
 

--- a/unic/ucd/normal/src/decomposition_type.rs
+++ b/unic/ucd/normal/src/decomposition_type.rs
@@ -12,7 +12,7 @@
 
 //! Accessor for *Decomposition_Type* (dt) property
 
-use unic_utils::CharBsearchTable;
+use unic_utils::CharDataTable;
 
 use composition::canonical_decomposition;
 use hangul;

--- a/unic/ucd/normal/src/gen_cat.rs
+++ b/unic/ucd/normal/src/gen_cat.rs
@@ -18,17 +18,7 @@ mod mark {
 
     /// Return whether the given character is a combining mark (`General_Category=Mark`)
     pub fn is_combining_mark(c: char) -> bool {
-        bsearch_range_table(c, GENERAL_CATEGORY_MARK)
-    }
-
-    fn bsearch_range_table(c: char, r: &'static [(char, char)]) -> bool {
-        r.binary_search_by(|&(lo, hi)| if lo <= c && c <= hi {
-            Ordering::Equal
-        } else if hi < c {
-            Ordering::Less
-        } else {
-            Ordering::Greater
-        }).is_ok()
+        GENERAL_CATEGORY_MARK.find(c).is_some()
     }
 }
 

--- a/unic/ucd/normal/src/lib.rs
+++ b/unic/ucd/normal/src/lib.rs
@@ -47,7 +47,7 @@ pub use decompose::{decompose_canonical, decompose_compatible};
 pub use decomposition_type::DecompositionType;
 
 use unic_ucd_core::UnicodeVersion;
-use unic_utils::CharBsearchTable;
+use unic_utils::CharDataTable;
 
 
 /// The [Unicode version](http://www.unicode.org/versions/) of data

--- a/unic/utils/src/lib.rs
+++ b/unic/utils/src/lib.rs
@@ -27,6 +27,8 @@ pub const PKG_DESCRIPTION: &'static str = env!("CARGO_PKG_DESCRIPTION");
 
 
 pub mod codepoints;
+pub mod tables;
 
 
 pub use codepoints::iter_all_chars;
+pub use tables::CharBsearchTable;

--- a/unic/utils/src/lib.rs
+++ b/unic/utils/src/lib.rs
@@ -31,4 +31,4 @@ pub mod tables;
 
 
 pub use codepoints::iter_all_chars;
-pub use tables::CharBsearchTable;
+pub use tables::CharDataTable;

--- a/unic/utils/src/tables.rs
+++ b/unic/utils/src/tables.rs
@@ -3,31 +3,31 @@
 use std::cmp;
 
 /// bananas
-pub trait CharBsearchTable<V: 'static> {
+pub trait CharBsearchTable<V> {
     /// bananas
-    fn find(&self, needle: char) -> Option<&V>;
+    fn find(&self, needle: char) -> Option<V>;
 
     /// bananas
-    fn binary_search_or<'a>(&'a self, needle: char, default: &'a V) -> &'a V {
+    fn binary_search_or(&self, needle: char, default: V) -> V {
         self.find(needle).unwrap_or(default)
     }
 
     /// bananas
-    fn binary_search_or_else<'a>(&'a self, needle: char, f: fn() -> &'a V) -> &'a V {
+    fn binary_search_or_else(&self, needle: char, f: fn() -> V) -> V {
         self.find(needle).unwrap_or_else(f)
     }
 }
 
-impl<V: 'static> CharBsearchTable<V> for &'static [(char, V)] {
-    fn find(&self, needle: char) -> Option<&V> {
+impl<'a, V> CharBsearchTable<&'a V> for &'a [(char, V)] {
+    fn find(&self, needle: char) -> Option<&'a V> {
         self.binary_search_by_key(&needle, |&(k, _)| k)
             .map(|idx| &self[idx].1)
             .ok()
     }
 }
 
-impl<V: 'static> CharBsearchTable<V> for &'static [(char, char, V)] {
-    fn find(&self, needle: char) -> Option<&V> {
+impl<'a, V> CharBsearchTable<&'a V> for &'a [(char, char, V)] {
+    fn find(&self, needle: char) -> Option<&'a V> {
         self.binary_search_by(|&(low, high, _)| if low > needle {
             cmp::Ordering::Greater
         } else if high < needle {
@@ -40,17 +40,14 @@ impl<V: 'static> CharBsearchTable<V> for &'static [(char, char, V)] {
 }
 
 impl CharBsearchTable<()> for &'static [(char, char)] {
-    fn find(&self, needle: char) -> Option<&()> {
+    fn find(&self, needle: char) -> Option<()> {
         self.binary_search_by(|&(low, high)| if low > needle {
             cmp::Ordering::Greater
         } else if high < needle {
             cmp::Ordering::Less
         } else {
             cmp::Ordering::Equal
-        }).map(|_| {
-                const UNIT: &() = &();
-                UNIT
-            })
+        }).map(|_| ())
             .ok()
     }
 }

--- a/unic/utils/src/tables.rs
+++ b/unic/utils/src/tables.rs
@@ -1,18 +1,18 @@
-//! bananas
+//! Trait and impls for character data tables used in UNIC.
 
 use std::cmp;
 
-/// bananas
+/// A table from characters to data associated with those characters.
 pub trait CharDataTable<V> {
-    /// bananas
+    /// Find the associated data for a character in this table.
     fn find(&self, needle: char) -> Option<V>;
 
-    /// bananas
+    /// Find the associated data for a character in this table or use a provided default.
     fn find_or(&self, needle: char, default: V) -> V {
         self.find(needle).unwrap_or(default)
     }
 
-    /// bananas
+    /// Find the associated data for a character in this table or generate a default.
     fn find_or_else<F>(&self, needle: char, f: F) -> V
     where
         F: FnOnce() -> V,

--- a/unic/utils/src/tables.rs
+++ b/unic/utils/src/tables.rs
@@ -13,7 +13,10 @@ pub trait CharBsearchTable<V> {
     }
 
     /// bananas
-    fn binary_search_or_else(&self, needle: char, f: fn() -> V) -> V {
+    fn binary_search_or_else<F>(&self, needle: char, f: F) -> V
+    where
+        F: FnOnce() -> V,
+    {
         self.find(needle).unwrap_or_else(f)
     }
 }

--- a/unic/utils/src/tables.rs
+++ b/unic/utils/src/tables.rs
@@ -3,17 +3,17 @@
 use std::cmp;
 
 /// bananas
-pub trait CharBsearchTable<V> {
+pub trait CharDataTable<V> {
     /// bananas
     fn find(&self, needle: char) -> Option<V>;
 
     /// bananas
-    fn binary_search_or(&self, needle: char, default: V) -> V {
+    fn find_or(&self, needle: char, default: V) -> V {
         self.find(needle).unwrap_or(default)
     }
 
     /// bananas
-    fn binary_search_or_else<F>(&self, needle: char, f: F) -> V
+    fn find_or_else<F>(&self, needle: char, f: F) -> V
     where
         F: FnOnce() -> V,
     {
@@ -21,7 +21,7 @@ pub trait CharBsearchTable<V> {
     }
 }
 
-impl<'a, V> CharBsearchTable<&'a V> for &'a [(char, V)] {
+impl<'a, V> CharDataTable<&'a V> for &'a [(char, V)] {
     fn find(&self, needle: char) -> Option<&'a V> {
         self.binary_search_by_key(&needle, |&(k, _)| k)
             .map(|idx| &self[idx].1)
@@ -29,7 +29,7 @@ impl<'a, V> CharBsearchTable<&'a V> for &'a [(char, V)] {
     }
 }
 
-impl<'a, V> CharBsearchTable<&'a V> for &'a [(char, char, V)] {
+impl<'a, V> CharDataTable<&'a V> for &'a [(char, char, V)] {
     fn find(&self, needle: char) -> Option<&'a V> {
         self.binary_search_by(|&(low, high, _)| if low > needle {
             cmp::Ordering::Greater
@@ -42,7 +42,7 @@ impl<'a, V> CharBsearchTable<&'a V> for &'a [(char, char, V)] {
     }
 }
 
-impl CharBsearchTable<()> for &'static [(char, char)] {
+impl CharDataTable<()> for &'static [(char, char)] {
     fn find(&self, needle: char) -> Option<()> {
         self.binary_search_by(|&(low, high)| if low > needle {
             cmp::Ordering::Greater

--- a/unic/utils/src/tables.rs
+++ b/unic/utils/src/tables.rs
@@ -1,0 +1,56 @@
+//! bananas
+
+use std::cmp;
+
+/// bananas
+pub trait CharBsearchTable<V: 'static> {
+    /// bananas
+    fn find(&self, needle: char) -> Option<&V>;
+
+    /// bananas
+    fn binary_search_or<'a>(&'a self, needle: char, default: &'a V) -> &'a V {
+        self.find(needle).unwrap_or(default)
+    }
+
+    /// bananas
+    fn binary_search_or_else<'a>(&'a self, needle: char, f: fn() -> &'a V) -> &'a V {
+        self.find(needle).unwrap_or_else(f)
+    }
+}
+
+impl<V: 'static> CharBsearchTable<V> for &'static [(char, V)] {
+    fn find(&self, needle: char) -> Option<&V> {
+        self.binary_search_by_key(&needle, |&(k, _)| k)
+            .map(|idx| &self[idx].1)
+            .ok()
+    }
+}
+
+impl<V: 'static> CharBsearchTable<V> for &'static [(char, char, V)] {
+    fn find(&self, needle: char) -> Option<&V> {
+        self.binary_search_by(|&(low, high, _)| if needle < low {
+            cmp::Ordering::Less
+        } else if needle > high {
+            cmp::Ordering::Greater
+        } else {
+            cmp::Ordering::Equal
+        }).map(|idx| &self[idx].2)
+            .ok()
+    }
+}
+
+impl CharBsearchTable<()> for &'static [(char, char)] {
+    fn find(&self, needle: char) -> Option<&()> {
+        self.binary_search_by(|&(low, high)| if needle < low {
+            cmp::Ordering::Less
+        } else if needle > high {
+            cmp::Ordering::Greater
+        } else {
+            cmp::Ordering::Equal
+        }).map(|_| {
+                const UNIT: &() = &();
+                UNIT
+            })
+            .ok()
+    }
+}

--- a/unic/utils/src/tables.rs
+++ b/unic/utils/src/tables.rs
@@ -28,10 +28,10 @@ impl<V: 'static> CharBsearchTable<V> for &'static [(char, V)] {
 
 impl<V: 'static> CharBsearchTable<V> for &'static [(char, char, V)] {
     fn find(&self, needle: char) -> Option<&V> {
-        self.binary_search_by(|&(low, high, _)| if needle < low {
-            cmp::Ordering::Less
-        } else if needle > high {
+        self.binary_search_by(|&(low, high, _)| if low > needle {
             cmp::Ordering::Greater
+        } else if high < needle {
+            cmp::Ordering::Less
         } else {
             cmp::Ordering::Equal
         }).map(|idx| &self[idx].2)
@@ -41,10 +41,10 @@ impl<V: 'static> CharBsearchTable<V> for &'static [(char, char, V)] {
 
 impl CharBsearchTable<()> for &'static [(char, char)] {
     fn find(&self, needle: char) -> Option<&()> {
-        self.binary_search_by(|&(low, high)| if needle < low {
-            cmp::Ordering::Less
-        } else if needle > high {
+        self.binary_search_by(|&(low, high)| if low > needle {
             cmp::Ordering::Greater
+        } else if high < needle {
+            cmp::Ordering::Less
         } else {
             cmp::Ordering::Equal
         }).map(|_| {

--- a/unic/utils/tests/table_tests.rs
+++ b/unic/utils/tests/table_tests.rs
@@ -1,0 +1,45 @@
+extern crate unic_utils;
+use unic_utils::CharBsearchTable;
+
+use std::char;
+
+#[test]
+fn range_value_table() {
+    const TABLE: &'static [(char, char, u32)] = &[('a', 'g', 1), ('j', 'q', 2), ('w', 'z', 3)];
+    const DEFAULT: &u32 = &0;
+    for i in ('a' as u32)..('g' as u32 + 1) {
+        if let Some(needle) = char::from_u32(i) {
+            assert_eq!(TABLE.find(needle), Some(&1));
+            assert_eq!(TABLE.binary_search_or(needle, DEFAULT), &1);
+            assert_eq!(TABLE.binary_search_or_else(needle, || DEFAULT), &1);
+        }
+    }
+    for i in ('h' as u32)..('i' as u32 + 1) {
+        if let Some(needle) = char::from_u32(i) {
+            assert_eq!(TABLE.find(needle), None);
+            assert_eq!(TABLE.binary_search_or(needle, DEFAULT), DEFAULT);
+            assert_eq!(TABLE.binary_search_or_else(needle, || DEFAULT), DEFAULT);
+        }
+    }
+    for i in ('j' as u32)..('q' as u32 + 1) {
+        if let Some(needle) = char::from_u32(i) {
+            assert_eq!(TABLE.find(needle), Some(&2));
+            assert_eq!(TABLE.binary_search_or(needle, DEFAULT), &2);
+            assert_eq!(TABLE.binary_search_or_else(needle, || DEFAULT), &2);
+        }
+    }
+    for i in ('r' as u32)..('v' as u32 + 1) {
+        if let Some(needle) = char::from_u32(i) {
+            assert_eq!(TABLE.find(needle), None);
+            assert_eq!(TABLE.binary_search_or(needle, DEFAULT), DEFAULT);
+            assert_eq!(TABLE.binary_search_or_else(needle, || DEFAULT), DEFAULT);
+        }
+    }
+    for i in ('x' as u32)..('z' as u32 + 1) {
+        if let Some(needle) = char::from_u32(i) {
+            assert_eq!(TABLE.find(needle), Some(&3));
+            assert_eq!(TABLE.binary_search_or(needle, DEFAULT), &3);
+            assert_eq!(TABLE.binary_search_or_else(needle, || DEFAULT), &3);
+        }
+    }
+}

--- a/unic/utils/tests/table_tests.rs
+++ b/unic/utils/tests/table_tests.rs
@@ -1,5 +1,5 @@
 extern crate unic_utils;
-use unic_utils::CharBsearchTable;
+use unic_utils::CharDataTable;
 
 use std::char;
 
@@ -10,36 +10,36 @@ fn range_value_table() {
     for i in ('a' as u32)..('g' as u32 + 1) {
         if let Some(needle) = char::from_u32(i) {
             assert_eq!(TABLE.find(needle), Some(&1));
-            assert_eq!(TABLE.binary_search_or(needle, DEFAULT), &1);
-            assert_eq!(TABLE.binary_search_or_else(needle, || DEFAULT), &1);
+            assert_eq!(TABLE.find_or(needle, DEFAULT), &1);
+            assert_eq!(TABLE.find_or_else(needle, || DEFAULT), &1);
         }
     }
     for i in ('h' as u32)..('i' as u32 + 1) {
         if let Some(needle) = char::from_u32(i) {
             assert_eq!(TABLE.find(needle), None);
-            assert_eq!(TABLE.binary_search_or(needle, DEFAULT), DEFAULT);
-            assert_eq!(TABLE.binary_search_or_else(needle, || DEFAULT), DEFAULT);
+            assert_eq!(TABLE.find_or(needle, DEFAULT), DEFAULT);
+            assert_eq!(TABLE.find_or_else(needle, || DEFAULT), DEFAULT);
         }
     }
     for i in ('j' as u32)..('q' as u32 + 1) {
         if let Some(needle) = char::from_u32(i) {
             assert_eq!(TABLE.find(needle), Some(&2));
-            assert_eq!(TABLE.binary_search_or(needle, DEFAULT), &2);
-            assert_eq!(TABLE.binary_search_or_else(needle, || DEFAULT), &2);
+            assert_eq!(TABLE.find_or(needle, DEFAULT), &2);
+            assert_eq!(TABLE.find_or_else(needle, || DEFAULT), &2);
         }
     }
     for i in ('r' as u32)..('v' as u32 + 1) {
         if let Some(needle) = char::from_u32(i) {
             assert_eq!(TABLE.find(needle), None);
-            assert_eq!(TABLE.binary_search_or(needle, DEFAULT), DEFAULT);
-            assert_eq!(TABLE.binary_search_or_else(needle, || DEFAULT), DEFAULT);
+            assert_eq!(TABLE.find_or(needle, DEFAULT), DEFAULT);
+            assert_eq!(TABLE.find_or_else(needle, || DEFAULT), DEFAULT);
         }
     }
     for i in ('x' as u32)..('z' as u32 + 1) {
         if let Some(needle) = char::from_u32(i) {
             assert_eq!(TABLE.find(needle), Some(&3));
-            assert_eq!(TABLE.binary_search_or(needle, DEFAULT), &3);
-            assert_eq!(TABLE.binary_search_or_else(needle, || DEFAULT), &3);
+            assert_eq!(TABLE.find_or(needle, DEFAULT), &3);
+            assert_eq!(TABLE.find_or_else(needle, || DEFAULT), &3);
         }
     }
 }


### PR DESCRIPTION
This attempts to consolidate all the different places that a `bsearch_range_value_table`-like fn was defined to one canonical definition in `unic-utils`.