### PR TITLE
[char_property] Implement *CharProperty traits

### DIFF
--- a/unic/ucd/age/src/age.rs
+++ b/unic/ucd/age/src/age.rs
@@ -11,10 +11,9 @@
 
 use std::fmt;
 
-use unic_utils::CharDataTable;
-
 pub use unic_ucd_core::UnicodeVersion;
-use unic_utils::CharProperty;
+use unic_utils::CharDataTable;
+use unic_utils::char_property::CompleteCharProperty;
 
 
 /// Represents values of the Unicode character property
@@ -42,7 +41,7 @@ pub enum Age {
     Unassigned, // Unassigned is older (larger) than any age
 }
 
-impl CharProperty for Age {
+impl CompleteCharProperty for Age {
     fn of(ch: char) -> Self {
         Self::of(ch)
     }

--- a/unic/ucd/age/src/age.rs
+++ b/unic/ucd/age/src/age.rs
@@ -14,6 +14,7 @@ use std::fmt;
 use unic_utils::CharDataTable;
 
 pub use unic_ucd_core::UnicodeVersion;
+use unic_utils::CharProperty;
 
 
 /// Represents values of the Unicode character property
@@ -39,6 +40,12 @@ pub enum Age {
 
     /// Unassigned Unicode Code Point (can be assigned in future).
     Unassigned, // Unassigned is older (larger) than any age
+}
+
+impl CharProperty for Age {
+    fn of(ch: char) -> Self {
+        Self::of(ch)
+    }
 }
 
 use Age::{Assigned, Unassigned};

--- a/unic/ucd/age/src/age.rs
+++ b/unic/ucd/age/src/age.rs
@@ -41,11 +41,13 @@ pub enum Age {
     Unassigned, // Unassigned is older (larger) than any age
 }
 
+
 impl CompleteCharProperty for Age {
     fn of(ch: char) -> Self {
         Self::of(ch)
     }
 }
+
 
 use Age::{Assigned, Unassigned};
 

--- a/unic/ucd/age/src/lib.rs
+++ b/unic/ucd/age/src/lib.rs
@@ -10,7 +10,7 @@
 // except according to those terms.
 
 
-#![forbid(unsafe_code)]
+#![forbid(unsafe_code, unconditional_recursion)]
 #![deny(missing_docs)]
 
 //! # UNIC — UCD — Character Age

--- a/unic/ucd/bidi/src/bidi_class.rs
+++ b/unic/ucd/bidi/src/bidi_class.rs
@@ -9,9 +9,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+
 use std::fmt;
 
-use unic_utils::CharDataTable;
+use unic_utils::{CharDataTable, CharProperty, EnumeratedCharProperty};
+
 
 /// Represents the Unicode character
 /// [*Bidi_Class*](http://www.unicode.org/reports/tr44/#Bidi_Class) property, also known as the
@@ -46,6 +48,18 @@ pub enum BidiClass {
     SegmentSeparator,
     WhiteSpace,
     // [UNIC_UPDATE_ON_UNICODE_UPDATE] Source: `tables/bidi_class_type.rsv`
+}
+
+impl CharProperty for BidiClass {
+    fn of(ch: char) -> Self {
+        Self::of(ch)
+    }
+}
+
+impl EnumeratedCharProperty for BidiClass {
+    fn all_values() -> &'static [Self] {
+        Self::all_values()
+    }
 }
 
 
@@ -112,6 +126,37 @@ impl BidiClass {
         // UCD/extracted/DerivedBidiClass.txt: "All code points not explicitly listed
         // for Bidi_Class have the value Left_To_Right (L)."
         *BIDI_CLASS_TABLE.find_or(ch, &L)
+    }
+
+    /// Exhaustive list of all `BidiClass` property values.
+    pub fn all_values() -> &'static [BidiClass] {
+        use BidiClass::*;
+        const ALL_VALUES: &[BidiClass] = &[
+            ArabicLetter,
+            ArabicNumber,
+            ParagraphSeparator,
+            BoundaryNeutral,
+            CommonSeparator,
+            EuropeanNumber,
+            EuropeanSeparator,
+            EuropeanTerminator,
+            FirstStrongIsolate,
+            LeftToRight,
+            LeftToRightEmbedding,
+            LeftToRightIsolate,
+            LeftToRightOverride,
+            NonspacingMark,
+            OtherNeutral,
+            PopDirectionalFormat,
+            PopDirectionalIsolate,
+            RightToLeft,
+            RightToLeftEmbedding,
+            RightToLeftIsolate,
+            RightToLeftOverride,
+            SegmentSeparator,
+            WhiteSpace,
+        ];
+        ALL_VALUES
     }
 
     /// Abbreviated name of the *Bidi_Class* property value.
@@ -215,6 +260,14 @@ impl BidiClass {
         }
     }
 }
+
+
+impl Default for BidiClass {
+    fn default() -> Self {
+        BidiClass::LeftToRight
+    }
+}
+
 
 impl fmt::Display for BidiClass {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/unic/ucd/bidi/src/bidi_class.rs
+++ b/unic/ucd/bidi/src/bidi_class.rs
@@ -12,7 +12,8 @@
 
 use std::fmt;
 
-use unic_utils::{CharDataTable, CharProperty, EnumeratedCharProperty};
+use unic_utils::CharDataTable;
+use unic_utils::char_property::{CompleteCharProperty, EnumeratedCharProperty};
 
 
 /// Represents the Unicode character
@@ -50,13 +51,13 @@ pub enum BidiClass {
     // [UNIC_UPDATE_ON_UNICODE_UPDATE] Source: `tables/bidi_class_type.rsv`
 }
 
-impl CharProperty for BidiClass {
+impl CompleteCharProperty for BidiClass {
     fn of(ch: char) -> Self {
         Self::of(ch)
     }
 }
 
-impl EnumeratedCharProperty for BidiClass {
+impl EnumeratedCharProperty<BidiClass> for BidiClass {
     fn all_values() -> &'static [Self] {
         Self::all_values()
     }

--- a/unic/ucd/bidi/src/bidi_class.rs
+++ b/unic/ucd/bidi/src/bidi_class.rs
@@ -51,13 +51,15 @@ pub enum BidiClass {
     // [UNIC_UPDATE_ON_UNICODE_UPDATE] Source: `tables/bidi_class_type.rsv`
 }
 
+
 impl CompleteCharProperty for BidiClass {
     fn of(ch: char) -> Self {
         Self::of(ch)
     }
 }
 
-impl EnumeratedCharProperty<BidiClass> for BidiClass {
+
+impl EnumeratedCharProperty for BidiClass {
     fn all_values() -> &'static [Self] {
         Self::all_values()
     }

--- a/unic/ucd/bidi/src/lib.rs
+++ b/unic/ucd/bidi/src/lib.rs
@@ -10,7 +10,7 @@
 // except according to those terms.
 
 
-#![forbid(unsafe_code)]
+#![forbid(unsafe_code, unconditional_recursion)]
 #![deny(missing_docs)]
 
 //! # UNIC — UCD — Bidi

--- a/unic/ucd/category/Cargo.toml
+++ b/unic/ucd/category/Cargo.toml
@@ -15,6 +15,6 @@ exclude = []
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
+matches = "0.1"
 unic-ucd-core = { path = "../core/", version = "0.5.0" }
 unic-utils = { path = "../../utils/", version = "0.5.0" }
-matches = "0.1"

--- a/unic/ucd/category/src/category.rs
+++ b/unic/ucd/category/src/category.rs
@@ -93,7 +93,7 @@ impl CompleteCharProperty for GeneralCategory {
 }
 
 
-impl EnumeratedCharProperty<GeneralCategory> for GeneralCategory {
+impl EnumeratedCharProperty for GeneralCategory {
     fn all_values() -> &'static [Self] {
         Self::all_values()
     }

--- a/unic/ucd/category/src/category.rs
+++ b/unic/ucd/category/src/category.rs
@@ -8,7 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use unic_utils::CharDataTable;
+
+use std::fmt;
+
+use unic_utils::{CharDataTable, CharProperty, EnumeratedCharProperty};
+
 
 /// Represents the Unicode Character
 /// [*General_Category*](http://unicode.org/reports/tr44/#General_Category) property.
@@ -16,7 +20,7 @@ use unic_utils::CharDataTable;
 /// This is a useful breakdown into various character types which can be used as a default
 /// categorization in implementations. For the property values, see
 /// [*General_Category Values*](http://unicode.org/reports/tr44/#General_Category_Values).
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum GeneralCategory {
     /// An uppercase letter (Short form: `Lu`)
     UppercaseLetter,
@@ -80,6 +84,21 @@ pub enum GeneralCategory {
     Unassigned,
 }
 
+
+impl CharProperty for GeneralCategory {
+    fn of(ch: char) -> Self {
+        Self::of(ch)
+    }
+}
+
+
+impl EnumeratedCharProperty for GeneralCategory {
+    fn all_values() -> &'static [Self] {
+        Self::all_values()
+    }
+}
+
+
 pub mod abbr_names {
     pub use super::GeneralCategory::UppercaseLetter as Lu;
     pub use super::GeneralCategory::LowercaseLetter as Ll;
@@ -124,8 +143,6 @@ impl GeneralCategory {
     }
 
     /// Exhaustive list of all `GeneralCategory` property values.
-    ///
-    /// Reference: <http://unicode.org/reports/tr44/#General_Category_Values>
     pub fn all_values() -> &'static [GeneralCategory] {
         use GeneralCategory::*;
         const ALL_VALUES: &[GeneralCategory] = &[
@@ -162,7 +179,15 @@ impl GeneralCategory {
         ];
         ALL_VALUES
     }
+
+    /// Human-readable description of the property value.
+    // TODO: Needs to be improved by returning long-name with underscores replaced by space.
+    #[inline]
+    pub fn display(&self) -> String {
+        format!("{:?}", self).to_owned()
+    }
 }
+
 
 impl GeneralCategory {
     /// `Lu` | `Ll` | `Lt`  (Short form: `LC`)
@@ -205,6 +230,21 @@ impl GeneralCategory {
         matches!(*self, Cc | Cf | Cs | Co | Cn)
     }
 }
+
+
+impl Default for GeneralCategory {
+    fn default() -> Self {
+        GeneralCategory::Unassigned
+    }
+}
+
+
+impl fmt::Display for GeneralCategory {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.display())
+    }
+}
+
 
 #[cfg(test)]
 mod tests {
@@ -303,5 +343,12 @@ mod tests {
             let c = char::from_u32(c).unwrap();
             assert_eq!(GC::of(c), GC::Unassigned);
         }
+    }
+
+    #[test]
+    fn test_display() {
+        //assert_eq!(format!("{}", GC::UppercaseLetter), "Uppercase Letter");
+        assert_eq!(format!("{}", GC::UppercaseLetter), "UppercaseLetter");
+        assert_eq!(format!("{}", GC::Unassigned), "Unassigned");
     }
 }

--- a/unic/ucd/category/src/category.rs
+++ b/unic/ucd/category/src/category.rs
@@ -11,7 +11,8 @@
 
 use std::fmt;
 
-use unic_utils::{CharDataTable, CharProperty, EnumeratedCharProperty};
+use unic_utils::CharDataTable;
+use unic_utils::char_property::{CompleteCharProperty, EnumeratedCharProperty};
 
 
 /// Represents the Unicode Character
@@ -85,14 +86,14 @@ pub enum GeneralCategory {
 }
 
 
-impl CharProperty for GeneralCategory {
+impl CompleteCharProperty for GeneralCategory {
     fn of(ch: char) -> Self {
         Self::of(ch)
     }
 }
 
 
-impl EnumeratedCharProperty for GeneralCategory {
+impl EnumeratedCharProperty<GeneralCategory> for GeneralCategory {
     fn all_values() -> &'static [Self] {
         Self::all_values()
     }

--- a/unic/ucd/category/src/lib.rs
+++ b/unic/ucd/category/src/lib.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![deny(unsafe_code, missing_docs)]
+#![deny(unsafe_code, missing_docs, unconditional_recursion)]
 
 //! # UNIC — UCD — Category
 //!
@@ -38,6 +38,7 @@
 
 #[macro_use]
 extern crate matches;
+
 extern crate unic_ucd_core;
 extern crate unic_utils;
 

--- a/unic/ucd/core/src/lib.rs
+++ b/unic/ucd/core/src/lib.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 
-#![forbid(unsafe_code, missing_docs)]
+#![forbid(unsafe_code, missing_docs, unconditional_recursion)]
 
 //! # UNIC — UCD — Core
 //!

--- a/unic/ucd/normal/src/canonical_combining_class.rs
+++ b/unic/ucd/normal/src/canonical_combining_class.rs
@@ -15,7 +15,9 @@
 //! Reference: <http://unicode.org/reports/tr44/#Canonical_Combining_Class_Values>
 
 
-use unic_utils::CharDataTable;
+use std::fmt;
+
+use unic_utils::{CharDataTable, CharProperty};
 
 
 /// Represents *Canonical_Combining_Class* property of a Unicode character.
@@ -82,14 +84,33 @@ pub mod values {
 }
 
 
+impl CharProperty for CanonicalCombiningClass {
+    fn of(ch: char) -> Self {
+        Self::of(ch)
+    }
+}
+
+
 const CANONICAL_COMBINING_CLASS_VALUES: &'static [(char, char, CanonicalCombiningClass)] =
     include!("tables/canonical_combining_class_values.rsv");
-
 
 impl CanonicalCombiningClass {
     /// Find the character *Canonical_Combining_Class* property value.
     pub fn of(ch: char) -> CanonicalCombiningClass {
         *CANONICAL_COMBINING_CLASS_VALUES.find_or(ch, &CanonicalCombiningClass(0))
+    }
+
+    /// Human-readable description of the property value.
+    // TODO: Needs to be improved by returning long-name with underscores replaced by space.
+    #[inline]
+    pub fn display(&self) -> String {
+        format!("{}", self.number())
+    }
+}
+
+impl fmt::Display for CanonicalCombiningClass {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.display())
     }
 }
 
@@ -225,5 +246,11 @@ mod tests {
         assert_eq!(CCC::of('\u{0300}').number(), 230);
         assert_eq!(CCC::of('\u{0315}').number(), 232);
         assert_eq!(CCC::of('\u{1e94a}').number(), 7);
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(format!("{}", CCC::of('\u{0000}')), "0");
+        assert_eq!(format!("{}", CCC::of('\u{0300}')), "230");
     }
 }

--- a/unic/ucd/normal/src/canonical_combining_class.rs
+++ b/unic/ucd/normal/src/canonical_combining_class.rs
@@ -17,7 +17,7 @@
 
 use std::fmt;
 
-use unic_utils::{CharDataTable, CharProperty};
+use unic_utils::{CharDataTable, CharProperty, NumericCharProperty};
 
 
 /// Represents *Canonical_Combining_Class* property of a Unicode character.
@@ -25,6 +25,21 @@ use unic_utils::{CharDataTable, CharProperty};
 /// * <http://unicode.org/reports/tr44/#Canonical_Combining_Class>
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct CanonicalCombiningClass(u8);
+
+
+impl CharProperty for CanonicalCombiningClass {
+    fn of(ch: char) -> Self {
+        Self::of(ch)
+    }
+}
+
+
+impl NumericCharProperty<u8> for CanonicalCombiningClass {
+    /// Get numeric value for character property value
+    fn number(&self) -> u8 {
+        self.number()
+    }
+}
 
 
 // TODO: Once we fully adopt 1.20 change these to associated consts on CanonicalCombiningClass
@@ -81,13 +96,6 @@ pub mod values {
     pub const DoubleAbove: CCC = CCC(234);
     /// Greek iota subscript only
     pub const IotaSubscript: CCC = CCC(240);
-}
-
-
-impl CharProperty for CanonicalCombiningClass {
-    fn of(ch: char) -> Self {
-        Self::of(ch)
-    }
 }
 
 

--- a/unic/ucd/normal/src/canonical_combining_class.rs
+++ b/unic/ucd/normal/src/canonical_combining_class.rs
@@ -35,7 +35,7 @@ impl CompleteCharProperty for CanonicalCombiningClass {
 }
 
 
-impl NumericCharProperty<CanonicalCombiningClass, u8> for CanonicalCombiningClass {
+impl NumericCharProperty<u8> for CanonicalCombiningClass {
     /// Get numeric value for character property value
     fn number(&self) -> u8 {
         self.number()

--- a/unic/ucd/normal/src/canonical_combining_class.rs
+++ b/unic/ucd/normal/src/canonical_combining_class.rs
@@ -17,7 +17,8 @@
 
 use std::fmt;
 
-use unic_utils::{CharDataTable, CharProperty, NumericCharProperty};
+use unic_utils::CharDataTable;
+use unic_utils::char_property::{CompleteCharProperty, NumericCharProperty};
 
 
 /// Represents *Canonical_Combining_Class* property of a Unicode character.
@@ -27,14 +28,14 @@ use unic_utils::{CharDataTable, CharProperty, NumericCharProperty};
 pub struct CanonicalCombiningClass(u8);
 
 
-impl CharProperty for CanonicalCombiningClass {
+impl CompleteCharProperty for CanonicalCombiningClass {
     fn of(ch: char) -> Self {
         Self::of(ch)
     }
 }
 
 
-impl NumericCharProperty<u8> for CanonicalCombiningClass {
+impl NumericCharProperty<CanonicalCombiningClass, u8> for CanonicalCombiningClass {
     /// Get numeric value for character property value
     fn number(&self) -> u8 {
         self.number()

--- a/unic/ucd/normal/src/decomposition_type.rs
+++ b/unic/ucd/normal/src/decomposition_type.rs
@@ -14,7 +14,8 @@
 
 use std::fmt;
 
-use unic_utils::{CharDataTable, EnumeratedCharProperty, OptionCharProperty};
+use unic_utils::CharDataTable;
+use unic_utils::char_property::{EnumeratedCharProperty, PartialCharProperty};
 
 use composition::canonical_decomposition;
 use hangul;
@@ -48,14 +49,14 @@ pub enum DecompositionType {
 }
 
 
-impl OptionCharProperty for DecompositionType {
+impl PartialCharProperty for DecompositionType {
     fn of(ch: char) -> Option<Self> {
         Self::of(ch)
     }
 }
 
 
-impl EnumeratedCharProperty for DecompositionType {
+impl EnumeratedCharProperty<DecompositionType> for DecompositionType {
     fn all_values() -> &'static [Self] {
         Self::all_values()
     }

--- a/unic/ucd/normal/src/decomposition_type.rs
+++ b/unic/ucd/normal/src/decomposition_type.rs
@@ -12,7 +12,9 @@
 
 //! Accessor for *Decomposition_Type* (dt) property
 
-use unic_utils::CharDataTable;
+use std::fmt;
+
+use unic_utils::{CharDataTable, EnumeratedCharProperty, OptionCharProperty};
 
 use composition::canonical_decomposition;
 use hangul;
@@ -22,7 +24,7 @@ use hangul;
 /// [*Decomposition_Type*](http://www.unicode.org/reports/tr44/#Decomposition_Type) property.
 ///
 /// * <http://www.unicode.org/reports/tr44/#Character_Decomposition_Mappings>
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[allow(missing_docs)]
 pub enum DecompositionType {
     Canonical, // abbreviated: Can
@@ -46,6 +48,20 @@ pub enum DecompositionType {
 }
 
 
+impl OptionCharProperty for DecompositionType {
+    fn of(ch: char) -> Option<Self> {
+        Self::of(ch)
+    }
+}
+
+
+impl EnumeratedCharProperty for DecompositionType {
+    fn all_values() -> &'static [Self] {
+        Self::all_values()
+    }
+}
+
+
 use self::DecompositionType::*;
 
 // TODO: Maybe merge this table with compatibility_decomposition_mapping ones
@@ -61,6 +77,46 @@ impl DecompositionType {
             return Some(Canonical);
         }
         COMPATIBILITY_DECOMPOSITION_TYPE_TABLE.find(ch).cloned()
+    }
+
+    /// Exhaustive list of all `DecompositionType` property values.
+    pub fn all_values() -> &'static [DecompositionType] {
+        use DecompositionType::*;
+        const ALL_VALUES: &[DecompositionType] = &[
+            Canonical,
+            Compat,
+            Circle,
+            Final,
+            Font,
+            Fraction,
+            Initial,
+            Isolated,
+            Medial,
+            Narrow,
+            Nobreak,
+            None,
+            Small,
+            Square,
+            Sub,
+            Super,
+            Vertical,
+            Wide,
+        ];
+        ALL_VALUES
+    }
+
+    /// Human-readable description of the property value.
+    // TODO: Needs to be improved by returning long-name with underscores replaced by space.
+    #[inline]
+    pub fn display(&self) -> String {
+        format!("{:?}", self).to_owned()
+    }
+}
+
+
+impl fmt::Display for DecompositionType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.display())
     }
 }
 
@@ -192,5 +248,10 @@ mod tests {
         assert_eq!(DT::of('\u{80000}'), None);
         assert_eq!(DT::of('\u{90000}'), None);
         assert_eq!(DT::of('\u{a0000}'), None);
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(format!("{}", DT::of('\u{a0}').unwrap()), "Nobreak");
     }
 }

--- a/unic/ucd/normal/src/decomposition_type.rs
+++ b/unic/ucd/normal/src/decomposition_type.rs
@@ -56,7 +56,7 @@ impl PartialCharProperty for DecompositionType {
 }
 
 
-impl EnumeratedCharProperty<DecompositionType> for DecompositionType {
+impl EnumeratedCharProperty for DecompositionType {
     fn all_values() -> &'static [Self] {
         Self::all_values()
     }

--- a/unic/ucd/normal/src/lib.rs
+++ b/unic/ucd/normal/src/lib.rs
@@ -10,7 +10,7 @@
 // except according to those terms.
 
 
-#![deny(unsafe_code, missing_docs)]
+#![deny(unsafe_code, missing_docs, unconditional_recursion)]
 
 //! # UNIC — UCD — Normalization
 //!

--- a/unic/ucd/src/lib.rs
+++ b/unic/ucd/src/lib.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 
-#![forbid(unsafe_code, missing_docs)]
+#![forbid(unsafe_code, missing_docs, unconditional_recursion)]
 
 //! # UNIC — Unicode Character Database
 //!

--- a/unic/utils/README.md
+++ b/unic/utils/README.md
@@ -1,0 +1,6 @@
+# UNIC — Utilities
+
+[![Crates.io](https://img.shields.io/crates/v/unic-utils.svg)](https://crates.io/crates/unic-utils)
+[![Documentation](https://docs.rs/unic-utils/badge.svg)](https://docs.rs/unic-utils/)
+
+This UNIC component provides utility libraries that do not depend on Unicode data.

--- a/unic/utils/README.md
+++ b/unic/utils/README.md
@@ -3,4 +3,4 @@
 [![Crates.io](https://img.shields.io/crates/v/unic-utils.svg)](https://crates.io/crates/unic-utils)
 [![Documentation](https://docs.rs/unic-utils/badge.svg)](https://docs.rs/unic-utils/)
 
-This UNIC component provides utility libraries that do not depend on Unicode data.
+This UNIC component provides utility libraries that do not depend on any data.

--- a/unic/utils/src/char_property.rs
+++ b/unic/utils/src/char_property.rs
@@ -20,41 +20,35 @@ use std::fmt::{Debug, Display};
 use std::hash::Hash;
 
 
-// == Completeness and Accessors ==
-
-/// Marker for character property types.
-pub trait CharProperty<T> {}
-
-// Make char property type T also a parameter to this trait, otherwise there will be "conflicting
-// implementation" error when marking traits below as `CharProperty`.
-impl<T> CharProperty<T> for T {}
-
-
-/// A Character Property defined on all characters.
-///
-/// Examples: *Age*, *Name*, *General_Category*, *Bidi_Class*
-pub trait CompleteCharProperty
-where
-    Self: Copy + Debug + Default + Display + Eq + Hash,
-{
-    /// Find the character property value.
-    fn of(ch: char) -> Self;
-}
-
+// == Property Domain ==
 
 /// A Character Property defined for some characters.
 ///
 /// Examples: *Decomposition_Type*, *Numeric_Type*
-pub trait PartialCharProperty
-where
-    Self: Copy + Debug + Display + Eq + Hash,
-{
+pub trait PartialCharProperty: Copy + Debug + Display + Eq + Hash {
     /// Find the character property value, or None.
     fn of(ch: char) -> Option<Self>;
 }
 
 
-// == Enumerated/Catalog Property Type ==
+/// A Character Property defined on all characters.
+///
+/// Examples: *Age*, *Name*, *General_Category*, *Bidi_Class*
+pub trait CompleteCharProperty: PartialCharProperty + Default {
+    /// Find the character property value.
+    fn of(ch: char) -> Self;
+}
+
+impl<T: CompleteCharProperty> PartialCharProperty for T {
+    fn of(ch: char) -> Option<Self> {
+        Some(<Self as CompleteCharProperty>::of(ch))
+    }
+}
+
+
+// == Property Range ==
+
+// === Enumerated/Catalog Types ===
 
 /// A Character Property with enumerated values.
 ///
@@ -63,16 +57,13 @@ where
 /// Usage Note: If the property is of type *Catalog*, it's recommended to (in some way) mark the
 /// type as *non-exhaustive*, so that adding new variants to the `enum` type won't result in API
 /// breakage.
-pub trait EnumeratedCharProperty<T: CharProperty<T>>: Sized
-where
-    Self: CharProperty<T>,
-{
+pub trait EnumeratedCharProperty: Sized + PartialCharProperty {
     /// Exhaustive list of all property values.
     fn all_values() -> &'static [Self];
 }
 
 
-// == Numeric Property Type ==
+// === Numeric Types ===
 
 /// Marker for numeric types accepted by `NumericCharProperty`.
 pub trait NumericCharPropertyValue {}
@@ -83,10 +74,8 @@ impl NumericCharPropertyValue for u8 {}
 /// A Character Property with numeric values.
 ///
 /// Examples: *Numeric_Value*, *Canonical_Combining_Class*
-pub trait NumericCharProperty<T: CharProperty<T>, Value: NumericCharPropertyValue>
-where
-    Self: CharProperty<T>,
-{
+pub trait NumericCharProperty<Value: NumericCharPropertyValue>
+    : PartialCharProperty {
     /// Get numeric value for character property value
     fn number(&self) -> Value;
 }

--- a/unic/utils/src/char_property.rs
+++ b/unic/utils/src/char_property.rs
@@ -9,38 +9,71 @@
 // except according to those terms.
 
 
-//! TBD.
+//! Taxonomy and Contracts for Character Property types.
+//!
+//! See also the list of types of character properties defined in the UCD:
+//! <http://unicode.org/reports/tr44/#About_Property_Table>, in [Unicode® Standard Annex #44 —
+//! Unicode Character Database](http://unicode.org/reports/tr44/#About_Property_Table)
 
 
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
 
 
-/// TBD.
+/// A Character Property defined on all characters.
+///
+/// Examples: *Age*, *Name*, *General_Category*, *Bidi_Class*
 pub trait CharProperty
 where
     Self: Copy + Debug + Default + Display + Eq + Hash,
 {
-    /// TBD
+    /// Find the character property value.
     fn of(ch: char) -> Self;
 }
 
 
-/// TBD.
+/// A Character Property defined for some characters.
+///
+/// Examples: *Decomposition_Type*, *Numeric_Type*
 pub trait OptionCharProperty
 where
     Self: Copy + Debug + Display + Eq + Hash,
 {
-    /// TBD
+    /// Find the character property value, or None.
     fn of(ch: char) -> Option<Self>;
 }
 
 
-/// TBD.
+/// A Character Property with enumerated values.
+///
+/// This is similar to types *Catalog* and *Enumeration*, as defined in UAX#44.
+///
+/// Usage Note: If the property is of type *Catalog* (as defined by Unicode), it's recommended to
+/// (in some way) mark the type as *non-exhaustive*, so that adding new variants to the `enum` type
+/// won't result in API breakage.
 pub trait EnumeratedCharProperty
 where
     Self: Copy + Debug + Display + Eq + Hash,
 {
-    /// TBD
+    /// Exhaustive list of all property values.
     fn all_values() -> &'static [Self];
+}
+
+
+/// Marker for numeric types accepted by `NumericCharProperty`.
+pub trait NumericCharPropertyValue {}
+
+impl NumericCharPropertyValue for u8 {}
+
+
+/// A Character Property with numeric values.
+///
+/// Examples: *Numeric_Value*, *Canonical_Combining_Class*
+pub trait NumericCharProperty<Value>
+where
+    Self: Copy + Debug + Default + Display + Eq + Hash,
+    Value: NumericCharPropertyValue,
+{
+    /// Get numeric value for character property value
+    fn number(&self) -> Value;
 }

--- a/unic/utils/src/char_property.rs
+++ b/unic/utils/src/char_property.rs
@@ -1,0 +1,46 @@
+// Copyright 2017 The UNIC Project Developers.
+//
+// See the COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+//! TBD.
+
+
+use std::fmt::{Debug, Display};
+use std::hash::Hash;
+
+
+/// TBD.
+pub trait CharProperty
+where
+    Self: Copy + Debug + Default + Display + Eq + Hash,
+{
+    /// TBD
+    fn of(ch: char) -> Self;
+}
+
+
+/// TBD.
+pub trait OptionCharProperty
+where
+    Self: Copy + Debug + Display + Eq + Hash,
+{
+    /// TBD
+    fn of(ch: char) -> Option<Self>;
+}
+
+
+/// TBD.
+pub trait EnumeratedCharProperty
+where
+    Self: Copy + Debug + Display + Eq + Hash,
+{
+    /// TBD
+    fn all_values() -> &'static [Self];
+}

--- a/unic/utils/src/char_property.rs
+++ b/unic/utils/src/char_property.rs
@@ -20,10 +20,20 @@ use std::fmt::{Debug, Display};
 use std::hash::Hash;
 
 
+// == Completeness and Accessors ==
+
+/// Marker for character property types.
+pub trait CharProperty<T> {}
+
+// Make char property type T also a parameter to this trait, otherwise there will be "conflicting
+// implementation" error when marking traits below as `CharProperty`.
+impl<T> CharProperty<T> for T {}
+
+
 /// A Character Property defined on all characters.
 ///
 /// Examples: *Age*, *Name*, *General_Category*, *Bidi_Class*
-pub trait CharProperty
+pub trait CompleteCharProperty
 where
     Self: Copy + Debug + Default + Display + Eq + Hash,
 {
@@ -35,7 +45,7 @@ where
 /// A Character Property defined for some characters.
 ///
 /// Examples: *Decomposition_Type*, *Numeric_Type*
-pub trait OptionCharProperty
+pub trait PartialCharProperty
 where
     Self: Copy + Debug + Display + Eq + Hash,
 {
@@ -44,21 +54,25 @@ where
 }
 
 
+// == Enumerated/Catalog Property Type ==
+
 /// A Character Property with enumerated values.
 ///
-/// This is similar to types *Catalog* and *Enumeration*, as defined in UAX#44.
+/// This is similar to types *Enumeration* and *Catalog*, as defined in UAX#44.
 ///
-/// Usage Note: If the property is of type *Catalog* (as defined by Unicode), it's recommended to
-/// (in some way) mark the type as *non-exhaustive*, so that adding new variants to the `enum` type
-/// won't result in API breakage.
-pub trait EnumeratedCharProperty
+/// Usage Note: If the property is of type *Catalog*, it's recommended to (in some way) mark the
+/// type as *non-exhaustive*, so that adding new variants to the `enum` type won't result in API
+/// breakage.
+pub trait EnumeratedCharProperty<T: CharProperty<T>>: Sized
 where
-    Self: Copy + Debug + Display + Eq + Hash,
+    Self: CharProperty<T>,
 {
     /// Exhaustive list of all property values.
     fn all_values() -> &'static [Self];
 }
 
+
+// == Numeric Property Type ==
 
 /// Marker for numeric types accepted by `NumericCharProperty`.
 pub trait NumericCharPropertyValue {}
@@ -69,10 +83,9 @@ impl NumericCharPropertyValue for u8 {}
 /// A Character Property with numeric values.
 ///
 /// Examples: *Numeric_Value*, *Canonical_Combining_Class*
-pub trait NumericCharProperty<Value>
+pub trait NumericCharProperty<T: CharProperty<T>, Value: NumericCharPropertyValue>
 where
-    Self: Copy + Debug + Default + Display + Eq + Hash,
-    Value: NumericCharPropertyValue,
+    Self: CharProperty<T>,
 {
     /// Get numeric value for character property value
     fn number(&self) -> Value;

--- a/unic/utils/src/lib.rs
+++ b/unic/utils/src/lib.rs
@@ -29,7 +29,9 @@ pub const PKG_DESCRIPTION: &'static str = env!("CARGO_PKG_DESCRIPTION");
 
 pub mod codepoints;
 pub mod tables;
+pub mod char_property;
 
 
+pub use char_property::{CharProperty, EnumeratedCharProperty, OptionCharProperty};
 pub use codepoints::iter_all_chars;
 pub use tables::CharDataTable;

--- a/unic/utils/src/lib.rs
+++ b/unic/utils/src/lib.rs
@@ -27,11 +27,16 @@ pub const PKG_NAME: &'static str = env!("CARGO_PKG_NAME");
 pub const PKG_DESCRIPTION: &'static str = env!("CARGO_PKG_DESCRIPTION");
 
 
+pub mod char_property;
 pub mod codepoints;
 pub mod tables;
-pub mod char_property;
 
 
-pub use char_property::{CharProperty, EnumeratedCharProperty, OptionCharProperty};
+pub use char_property::{
+    CharProperty,
+    EnumeratedCharProperty,
+    NumericCharProperty,
+    OptionCharProperty,
+};
 pub use codepoints::iter_all_chars;
 pub use tables::CharDataTable;

--- a/unic/utils/src/lib.rs
+++ b/unic/utils/src/lib.rs
@@ -32,11 +32,5 @@ pub mod codepoints;
 pub mod tables;
 
 
-pub use char_property::{
-    CharProperty,
-    EnumeratedCharProperty,
-    NumericCharProperty,
-    OptionCharProperty,
-};
 pub use codepoints::iter_all_chars;
 pub use tables::CharDataTable;


### PR DESCRIPTION
Character Properties are of different kinds and shapes, and as UNIC
components grow, we need a better way to be able to categorize them by
their shape, and a way to make sure we have consistent, noncolliding
API for them.

This is the first step into building a CharProperty taxonomy, with as
little as possibly needed to provide the assurances desired.

We hope that the implementation can be improved over time with new
features added to the language. There's already some proposals in this
front. See these discussions for more details:

* [Traits as contract, without changes to call-sites](https://users.rust-lang.org/t/traits-as-contract-without-changes-to-call-sites/11938/11)

* [RFC: delegation of implementation](https://github.com/rust-lang/rfcs#1406)
