### PR TITLE
[char_property] Add EnumeratedCharProperty::abbr_name()

### DIFF
--- a/unic/bidi/tests/conformance_tests.rs
+++ b/unic/bidi/tests/conformance_tests.rs
@@ -242,12 +242,12 @@ fn gen_base_level_for_characters_tests(idx: usize) -> Option<Level> {
 fn get_sample_string_from_bidi_classes(class_names: &[&str]) -> String {
     class_names
         .iter()
-        .map(|class_name| gen_char_from_bidi_class(class_name))
+        .map(|bidi_class_abbr| gen_char_from_bidi_class_abbr(bidi_class_abbr))
         .collect()
 }
 
-fn gen_char_from_bidi_class(class_name: &str) -> char {
-    match class_name {
+fn gen_char_from_bidi_class_abbr(bidi_class_abbr: &str) -> char {
+    match bidi_class_abbr {
         "AL" => '\u{060B}',
         "AN" => '\u{0605}',
         "B" => '\u{000A}',
@@ -271,7 +271,7 @@ fn gen_char_from_bidi_class(class_name: &str) -> char {
         "RLO" => format_chars::RLO,
         "S" => '\u{001F}',
         "WS" => '\u{200A}',
-        &_ => panic!("Invalid Bidi_Class name: {}", class_name),
+        &_ => panic!("Invalid Bidi_Class name: {}", bidi_class_abbr),
     }
 }
 
@@ -304,8 +304,8 @@ fn test_gen_char_from_bidi_class() {
         S,
         WS,
     ] {
-        let class_name = class.abbr_name();
-        let sample_char = gen_char_from_bidi_class(class_name);
+        let bidi_class_abbr = class.abbr_name();
+        let sample_char = gen_char_from_bidi_class_abbr(bidi_class_abbr);
         assert_eq!(BidiClass::of(sample_char), class);
     }
 }

--- a/unic/ucd/bidi/src/bidi_class.rs
+++ b/unic/ucd/bidi/src/bidi_class.rs
@@ -63,6 +63,10 @@ impl EnumeratedCharProperty for BidiClass {
     fn all_values() -> &'static [Self] {
         Self::all_values()
     }
+
+    fn abbr_name(&self) -> &'static str {
+        self.abbr_name()
+    }
 }
 
 
@@ -165,31 +169,32 @@ impl BidiClass {
     /// Abbreviated name of the *Bidi_Class* property value.
     ///
     /// <http://www.unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt#Bidi_Class>
-    pub fn abbr_name(&self) -> &str {
+    pub fn abbr_name(&self) -> &'static str {
+        use BidiClass::*;
         match *self {
-            BidiClass::ArabicLetter => "AL",
-            BidiClass::ArabicNumber => "AN",
-            BidiClass::ParagraphSeparator => "B",
-            BidiClass::BoundaryNeutral => "BN",
-            BidiClass::CommonSeparator => "CS",
-            BidiClass::EuropeanNumber => "EN",
-            BidiClass::EuropeanSeparator => "ES",
-            BidiClass::EuropeanTerminator => "ET",
-            BidiClass::FirstStrongIsolate => "FSI",
-            BidiClass::LeftToRight => "L",
-            BidiClass::LeftToRightEmbedding => "LRE",
-            BidiClass::LeftToRightIsolate => "LRI",
-            BidiClass::LeftToRightOverride => "LRO",
-            BidiClass::NonspacingMark => "NSM",
-            BidiClass::OtherNeutral => "ON",
-            BidiClass::PopDirectionalFormat => "PDF",
-            BidiClass::PopDirectionalIsolate => "PDI",
-            BidiClass::RightToLeft => "R",
-            BidiClass::RightToLeftEmbedding => "RLE",
-            BidiClass::RightToLeftIsolate => "RLI",
-            BidiClass::RightToLeftOverride => "RLO",
-            BidiClass::SegmentSeparator => "S",
-            BidiClass::WhiteSpace => "WS",
+            ArabicLetter => "AL",
+            ArabicNumber => "AN",
+            ParagraphSeparator => "B",
+            BoundaryNeutral => "BN",
+            CommonSeparator => "CS",
+            EuropeanNumber => "EN",
+            EuropeanSeparator => "ES",
+            EuropeanTerminator => "ET",
+            FirstStrongIsolate => "FSI",
+            LeftToRight => "L",
+            LeftToRightEmbedding => "LRE",
+            LeftToRightIsolate => "LRI",
+            LeftToRightOverride => "LRO",
+            NonspacingMark => "NSM",
+            OtherNeutral => "ON",
+            PopDirectionalFormat => "PDF",
+            PopDirectionalIsolate => "PDI",
+            RightToLeft => "R",
+            RightToLeftEmbedding => "RLE",
+            RightToLeftIsolate => "RLI",
+            RightToLeftOverride => "RLO",
+            SegmentSeparator => "S",
+            WhiteSpace => "WS",
         }
     }
 
@@ -371,5 +376,10 @@ mod tests {
         assert_eq!(format!("{}", R), "Right-to-Left");
         assert_eq!(format!("{}", AL), "Right-to-Left Arabic");
         assert_eq!(format!("{}", FSI), "First Strong Isolate");
+    }
+
+    #[test]
+    fn test_abbr_name() {
+        assert_eq!(AL.abbr_name(), "AL");
     }
 }

--- a/unic/ucd/category/src/category.rs
+++ b/unic/ucd/category/src/category.rs
@@ -97,40 +97,44 @@ impl EnumeratedCharProperty for GeneralCategory {
     fn all_values() -> &'static [Self] {
         Self::all_values()
     }
+
+    fn abbr_name(&self) -> &'static str {
+        self.abbr_name()
+    }
 }
 
 
 pub mod abbr_names {
-    pub use super::GeneralCategory::UppercaseLetter as Lu;
-    pub use super::GeneralCategory::LowercaseLetter as Ll;
-    pub use super::GeneralCategory::TitlecaseLetter as Lt;
-    pub use super::GeneralCategory::ModifierLetter as Lm;
-    pub use super::GeneralCategory::OtherLetter as Lo;
-    pub use super::GeneralCategory::NonspacingMark as Mn;
-    pub use super::GeneralCategory::SpacingMark as Mc;
-    pub use super::GeneralCategory::EnclosingMark as Me;
-    pub use super::GeneralCategory::DecimalNumber as Nd;
-    pub use super::GeneralCategory::LetterNumber as Nl;
-    pub use super::GeneralCategory::OtherNumber as No;
-    pub use super::GeneralCategory::ConnectorPunctuation as Pc;
-    pub use super::GeneralCategory::DashPunctuation as Pd;
-    pub use super::GeneralCategory::OpenPunctuation as Ps;
-    pub use super::GeneralCategory::ClosePunctuation as Pe;
-    pub use super::GeneralCategory::InitialPunctuation as Pi;
-    pub use super::GeneralCategory::FinalPunctuation as Pf;
-    pub use super::GeneralCategory::OtherPunctuation as Po;
-    pub use super::GeneralCategory::MathSymbol as Sm;
-    pub use super::GeneralCategory::CurrencySymbol as Sc;
-    pub use super::GeneralCategory::ModifierSymbol as Sk;
-    pub use super::GeneralCategory::OtherSymbol as So;
-    pub use super::GeneralCategory::SpaceSeparator as Zs;
-    pub use super::GeneralCategory::LineSeparator as Zl;
-    pub use super::GeneralCategory::ParagraphSeparator as Zp;
-    pub use super::GeneralCategory::Control as Cc;
-    pub use super::GeneralCategory::Format as Cf;
-    pub use super::GeneralCategory::Surrogate as Cs;
-    pub use super::GeneralCategory::PrivateUse as Co;
-    pub use super::GeneralCategory::Unassigned as Cn;
+    pub use GeneralCategory::UppercaseLetter as Lu;
+    pub use GeneralCategory::LowercaseLetter as Ll;
+    pub use GeneralCategory::TitlecaseLetter as Lt;
+    pub use GeneralCategory::ModifierLetter as Lm;
+    pub use GeneralCategory::OtherLetter as Lo;
+    pub use GeneralCategory::NonspacingMark as Mn;
+    pub use GeneralCategory::SpacingMark as Mc;
+    pub use GeneralCategory::EnclosingMark as Me;
+    pub use GeneralCategory::DecimalNumber as Nd;
+    pub use GeneralCategory::LetterNumber as Nl;
+    pub use GeneralCategory::OtherNumber as No;
+    pub use GeneralCategory::ConnectorPunctuation as Pc;
+    pub use GeneralCategory::DashPunctuation as Pd;
+    pub use GeneralCategory::OpenPunctuation as Ps;
+    pub use GeneralCategory::ClosePunctuation as Pe;
+    pub use GeneralCategory::InitialPunctuation as Pi;
+    pub use GeneralCategory::FinalPunctuation as Pf;
+    pub use GeneralCategory::OtherPunctuation as Po;
+    pub use GeneralCategory::MathSymbol as Sm;
+    pub use GeneralCategory::CurrencySymbol as Sc;
+    pub use GeneralCategory::ModifierSymbol as Sk;
+    pub use GeneralCategory::OtherSymbol as So;
+    pub use GeneralCategory::SpaceSeparator as Zs;
+    pub use GeneralCategory::LineSeparator as Zl;
+    pub use GeneralCategory::ParagraphSeparator as Zp;
+    pub use GeneralCategory::Control as Cc;
+    pub use GeneralCategory::Format as Cf;
+    pub use GeneralCategory::Surrogate as Cs;
+    pub use GeneralCategory::PrivateUse as Co;
+    pub use GeneralCategory::Unassigned as Cn;
 }
 use self::abbr_names::*;
 
@@ -179,6 +183,45 @@ impl GeneralCategory {
             Unassigned,
         ];
         ALL_VALUES
+    }
+
+    /// Abbreviated name of the *General_Category* property value.
+    ///
+    /// <http://www.unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt#General_Category>
+    pub fn abbr_name(&self) -> &'static str {
+        use GeneralCategory::*;
+        match *self {
+            UppercaseLetter => "Lu",
+            LowercaseLetter => "Ll",
+            TitlecaseLetter => "Lt",
+            ModifierLetter => "Lm",
+            OtherLetter => "Lo",
+            NonspacingMark => "Mn",
+            SpacingMark => "Mc",
+            EnclosingMark => "Me",
+            DecimalNumber => "Nd",
+            LetterNumber => "Nl",
+            OtherNumber => "No",
+            ConnectorPunctuation => "Pc",
+            DashPunctuation => "Pd",
+            OpenPunctuation => "Ps",
+            ClosePunctuation => "Pe",
+            InitialPunctuation => "Pi",
+            FinalPunctuation => "Pf",
+            OtherPunctuation => "Po",
+            MathSymbol => "Sm",
+            CurrencySymbol => "Sc",
+            ModifierSymbol => "Sk",
+            OtherSymbol => "So",
+            SpaceSeparator => "Zs",
+            LineSeparator => "Zl",
+            ParagraphSeparator => "Zp",
+            Control => "Cc",
+            Format => "Cf",
+            Surrogate => "Cs",
+            PrivateUse => "Co",
+            Unassigned => "Cn",
+        }
     }
 
     /// Human-readable description of the property value.
@@ -351,5 +394,11 @@ mod tests {
         //assert_eq!(format!("{}", GC::UppercaseLetter), "Uppercase Letter");
         assert_eq!(format!("{}", GC::UppercaseLetter), "UppercaseLetter");
         assert_eq!(format!("{}", GC::Unassigned), "Unassigned");
+    }
+
+    #[test]
+    fn test_abbr_name() {
+        use super::abbr_names::*;
+        assert_eq!(Lu.abbr_name(), "Lu");
     }
 }

--- a/unic/ucd/normal/src/decomposition_type.rs
+++ b/unic/ucd/normal/src/decomposition_type.rs
@@ -28,24 +28,24 @@ use hangul;
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[allow(missing_docs)]
 pub enum DecompositionType {
-    Canonical, // abbreviated: Can
-    Compat,    // abbreviated: Com
-    Circle,    // abbreviated: Enc
-    Final,     // abbreviated: Fin
-    Font,      // abbreviated: Font
-    Fraction,  // abbreviated: Fra
-    Initial,   // abbreviated: Init
-    Isolated,  // abbreviated: Iso
-    Medial,    // abbreviated: Med
-    Narrow,    // abbreviated: Nar
-    Nobreak,   // abbreviated: Nb
-    None,      // abbreviated: None
-    Small,     // abbreviated: Sml
-    Square,    // abbreviated: Sqr
-    Sub,       // abbreviated: Sub
-    Super,     // abbreviated: Sup
-    Vertical,  // abbreviated: Vert
-    Wide,      // abbreviated: Wide
+    Canonical,
+    Compat,
+    Circle,
+    Final,
+    Font,
+    Fraction,
+    Initial,
+    Isolated,
+    Medial,
+    Narrow,
+    Nobreak,
+    None,
+    Small,
+    Square,
+    Sub,
+    Super,
+    Vertical,
+    Wide,
 }
 
 
@@ -60,6 +60,32 @@ impl EnumeratedCharProperty for DecompositionType {
     fn all_values() -> &'static [Self] {
         Self::all_values()
     }
+
+    fn abbr_name(&self) -> &'static str {
+        self.abbr_name()
+    }
+}
+
+
+pub mod abbr_names {
+    pub use DecompositionType::Canonical as Can;
+    pub use DecompositionType::Compat as Com;
+    pub use DecompositionType::Circle as Enc;
+    pub use DecompositionType::Final as Fin;
+    pub use DecompositionType::Font as Font;
+    pub use DecompositionType::Fraction as Fra;
+    pub use DecompositionType::Initial as Init;
+    pub use DecompositionType::Isolated as Iso;
+    pub use DecompositionType::Medial as Med;
+    pub use DecompositionType::Narrow as Nar;
+    pub use DecompositionType::Nobreak as Nb;
+    pub use DecompositionType::None as None;
+    pub use DecompositionType::Small as Sml;
+    pub use DecompositionType::Square as Sqr;
+    pub use DecompositionType::Sub as Sub;
+    pub use DecompositionType::Super as Sup;
+    pub use DecompositionType::Vertical as Vert;
+    pub use DecompositionType::Wide as Wide;
 }
 
 
@@ -104,6 +130,33 @@ impl DecompositionType {
             Wide,
         ];
         ALL_VALUES
+    }
+
+    /// Abbreviated name of the *Decomposition_Type* property value.
+    ///
+    /// <http://www.unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt#Decomposition_Type>
+    pub fn abbr_name(&self) -> &'static str {
+        use DecompositionType::*;
+        match *self {
+            Canonical => "Can",
+            Compat => "Com",
+            Circle => "Enc",
+            Final => "Fin",
+            Font => "Font",
+            Fraction => "Fra",
+            Initial => "Init",
+            Isolated => "Iso",
+            Medial => "Med",
+            Narrow => "Nar",
+            Nobreak => "Nb",
+            None => "None",
+            Small => "Sml",
+            Square => "Sqr",
+            Sub => "Sub",
+            Super => "Sup",
+            Vertical => "Vert",
+            Wide => "Wide",
+        }
     }
 
     /// Human-readable description of the property value.
@@ -254,5 +307,11 @@ mod tests {
     #[test]
     fn test_display() {
         assert_eq!(format!("{}", DT::of('\u{a0}').unwrap()), "Nobreak");
+    }
+
+    #[test]
+    fn test_abbr_name() {
+        use super::abbr_names::*;
+        assert_eq!(Can.abbr_name(), "Can");
     }
 }

--- a/unic/utils/src/char_property.rs
+++ b/unic/utils/src/char_property.rs
@@ -60,6 +60,9 @@ impl<T: CompleteCharProperty> PartialCharProperty for T {
 pub trait EnumeratedCharProperty: Sized + PartialCharProperty {
     /// Exhaustive list of all property values.
     fn all_values() -> &'static [Self];
+
+    /// Get *abbreviated name* of the property value
+    fn abbr_name(&self) -> &'static str;
 }
 
 


### PR DESCRIPTION
Add `abbr_name()` to the `EnumeratedCharProperty` contract and implement
method for UCD properties missing it.

Also, add `pub mod abbr_names` too all these properties, and add a
simple test for mapping of `abbr_names` name and `abbr_name()` value.