### PR TITLE
[char_property] Manually enforce CompleteCharProperty inherited traits

### DIFF
--- a/unic/bidi/tests/conformance_tests.rs
+++ b/unic/bidi/tests/conformance_tests.rs
@@ -242,7 +242,9 @@ fn gen_base_level_for_characters_tests(idx: usize) -> Option<Level> {
 fn get_sample_string_from_bidi_classes(class_names: &[&str]) -> String {
     class_names
         .iter()
-        .map(|bidi_class_abbr| gen_char_from_bidi_class_abbr(bidi_class_abbr))
+        .map(|bidi_class_abbr| {
+            gen_char_from_bidi_class_abbr(bidi_class_abbr)
+        })
         .collect()
 }
 

--- a/unic/ucd/normal/src/decomposition_type.rs
+++ b/unic/ucd/normal/src/decomposition_type.rs
@@ -72,20 +72,20 @@ pub mod abbr_names {
     pub use DecompositionType::Compat as Com;
     pub use DecompositionType::Circle as Enc;
     pub use DecompositionType::Final as Fin;
-    pub use DecompositionType::Font as Font;
+    pub use DecompositionType::Font;
     pub use DecompositionType::Fraction as Fra;
     pub use DecompositionType::Initial as Init;
     pub use DecompositionType::Isolated as Iso;
     pub use DecompositionType::Medial as Med;
     pub use DecompositionType::Narrow as Nar;
     pub use DecompositionType::Nobreak as Nb;
-    pub use DecompositionType::None as None;
+    pub use DecompositionType::None;
     pub use DecompositionType::Small as Sml;
     pub use DecompositionType::Square as Sqr;
-    pub use DecompositionType::Sub as Sub;
+    pub use DecompositionType::Sub;
     pub use DecompositionType::Super as Sup;
     pub use DecompositionType::Vertical as Vert;
-    pub use DecompositionType::Wide as Wide;
+    pub use DecompositionType::Wide;
 }
 
 

--- a/unic/utils/src/char_property.rs
+++ b/unic/utils/src/char_property.rs
@@ -34,7 +34,11 @@ pub trait PartialCharProperty: Copy + Debug + Display + Eq + Hash {
 /// A Character Property defined on all characters.
 ///
 /// Examples: *Age*, *Name*, *General_Category*, *Bidi_Class*
-pub trait CompleteCharProperty: PartialCharProperty + Default {
+// Because of rustc bug, we cannot rely on inheritance for the moment.
+// See: <https://github.com/rust-lang/rust/issues/43777>
+//pub trait CompleteCharProperty: PartialCharProperty + Default {
+pub trait CompleteCharProperty
+    : PartialCharProperty + Copy + Debug + Display + Eq + Hash + Default {
     /// Find the character property value.
     fn of(ch: char) -> Self;
 }


### PR DESCRIPTION
See this bug report for why we need to do this at the moment: https://github.com/rust-lang/rust/issues/43777