### PR TITLE
[utils] Make char_property FromStr impl ascii case insensitive

### DIFF
--- a/unic/utils/src/macros.rs
+++ b/unic/utils/src/macros.rs
@@ -299,6 +299,18 @@ macro_rules! __char_property_internal {
                     $( stringify!($variant) => Ok($name::$variant), )*
                     $( stringify!($abbr) => Ok($name::$abbr_variant), )*
                     $( stringify!($long) => Ok($name::$long_variant), )*
+                    $( str
+                        if ::std::ascii::AsciiExt::eq_ignore_ascii_case(str, stringify!($variant))
+                        => Ok($name::$variant),
+                     )*
+                    $( str
+                        if ::std::ascii::AsciiExt::eq_ignore_ascii_case(str, stringify!($abbr))
+                        => Ok($name::$abbr_variant),
+                     )*
+                    $( str
+                        if ::std::ascii::AsciiExt::eq_ignore_ascii_case(str, stringify!($long))
+                        => Ok($name::$long_variant),
+                     )*
                     _ => Err(()),
                 }
             }

--- a/unic/utils/tests/macro_tests.rs
+++ b/unic/utils/tests/macro_tests.rs
@@ -54,3 +54,12 @@ fn basic_macro_use() {
     assert_eq!(format!("{}", Property::DisplayVariant), "The one and only DISPLAY VARIANT!");
     assert_eq!(format!("{}", Property::EmptyVariant), "EV");
 }
+
+#[test]
+fn fromstr_ignores_case() {
+    use abbr_names::LV;
+    assert_eq!("long_variant".parse(), Ok(LV));
+    assert_eq!("lOnG_vArIaNt".parse(), Ok(LV));
+    assert_eq!("LoNg_VaRiAnT".parse(), Ok(LV));
+    assert_eq!("LONG_VARIANT".parse(), Ok(LV));
+}


### PR DESCRIPTION
[`std::ascii::AsciiExt::eq_ignore_asci_case`](https://doc.rust-lang.org/std/ascii/trait.AsciiExt.html#tymethod.eq_ignore_ascii_case)

We still check for simple equality first, so simple equality should still be fast.