### PR TITLE
[ucd/normal] Add use-ucd-category feature

### DIFF
--- a/unic/ucd/Cargo.toml
+++ b/unic/ucd/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 unic-ucd-age = { path = "age/", version = "0.5.0" }
 unic-ucd-bidi = { path = "bidi/", version = "0.5.0" }
 unic-ucd-core = { path = "core/", version = "0.5.0" }
-unic-ucd-normal = { path = "normal/", version = "0.5.0", features = ["unic-ucd-category"] }
+unic-ucd-normal = { path = "normal/", version = "0.5.0", features = ["use-ucd-category"] }
 unic-ucd-category = { path = "category/", version = "0.5.0" }
 
 [dev-dependencies]

--- a/unic/ucd/normal/Cargo.toml
+++ b/unic/ucd/normal/Cargo.toml
@@ -11,9 +11,6 @@ categories = ["text-processing", "parsing", "rendering"]
 # No tests/benches that depends on /data/
 exclude = ["tests/conformance_tests.rs"]
 
-[features]
-default = []
-
 [badges]
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
@@ -25,3 +22,7 @@ unic-utils = { path = "../../utils/", version = "0.5.0" }
 [dev-dependencies]
 unic-utils = { path = "../../utils", version = "0.5.0" }
 unic-ucd-category = { path = "../category/", version = "0.5.0" }
+
+[features]
+default = []
+use-ucd-category = ["unic-ucd-category"]

--- a/unic/ucd/normal/src/gen_cat.rs
+++ b/unic/ucd/normal/src/gen_cat.rs
@@ -9,7 +9,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[cfg(not(feature = "unic-ucd-category"))]
+#[cfg(not(feature = "use-ucd-category"))]
 mod mark {
     use unic_utils::CharDataTable;
 
@@ -22,9 +22,10 @@ mod mark {
     }
 }
 
-#[cfg(feature = "unic-ucd-category")]
+#[cfg(feature = "use-ucd-category")]
 mod mark {
     extern crate unic_ucd_category;
+
     use self::unic_ucd_category::GeneralCategory;
 
     /// Return whether the given character is a combining mark (`General_Category=Mark`)


### PR DESCRIPTION
Basically, the dev dep record has been auto-enabling the optional dev
record for all test builds, resulting in the error to not surface.

Fix for the error surfacing by this change is
<https://github.com/behnam/rust-unic/pull/104>.

The original issue, which is (IMHO) unexpected Cargo behavior is filed
here: <https://github.com/rust-lang/cargo/issues/4395>