### PR TITLE
[ucd/normal] Drop use-ucd-category feature

### DIFF
--- a/unic/ucd/Cargo.toml
+++ b/unic/ucd/Cargo.toml
@@ -18,9 +18,9 @@ travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 [dependencies]
 unic-ucd-age = { path = "age/", version = "0.5.0" }
 unic-ucd-bidi = { path = "bidi/", version = "0.5.0" }
-unic-ucd-core = { path = "core/", version = "0.5.0" }
-unic-ucd-normal = { path = "normal/", version = "0.5.0", features = ["use-ucd-category"] }
 unic-ucd-category = { path = "category/", version = "0.5.0" }
+unic-ucd-core = { path = "core/", version = "0.5.0" }
+unic-ucd-normal = { path = "normal/", version = "0.5.0", features = ["unic-ucd-category"] }
 
 [dev-dependencies]
 unic-utils = { path = "../utils/", version = "0.5.0" }

--- a/unic/ucd/normal/Cargo.toml
+++ b/unic/ucd/normal/Cargo.toml
@@ -25,4 +25,3 @@ unic-ucd-category = { path = "../category/", version = "0.5.0" }
 
 [features]
 default = []
-use-ucd-category = ["unic-ucd-category"]

--- a/unic/ucd/normal/src/gen_cat.rs
+++ b/unic/ucd/normal/src/gen_cat.rs
@@ -9,7 +9,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[cfg(not(feature = "use-ucd-category"))]
+#[cfg(not(feature = "unic-ucd-category"))]
 mod mark {
     use unic_utils::CharDataTable;
 
@@ -22,7 +22,7 @@ mod mark {
     }
 }
 
-#[cfg(feature = "use-ucd-category")]
+#[cfg(feature = "unic-ucd-category")]
 mod mark {
     extern crate unic_ucd_category;
 

--- a/unic/ucd/normal/tests/general_category_tests.rs
+++ b/unic/ucd/normal/tests/general_category_tests.rs
@@ -9,6 +9,10 @@
 // except according to those terms.
 
 
+// Run these tests only if using local GC=Mark implementation
+#![cfg(not(feature = "unic-ucd-category"))]
+
+
 extern crate unic_ucd_category;
 extern crate unic_ucd_normal;
 extern crate unic_utils;
@@ -25,7 +29,7 @@ use self::unic_utils::iter_all_chars;
 /// Since `unic-ucd-category` feature is not enabled, `is_combining_mark` resolves to the local
 /// implementation.
 #[test]
-fn test_gen_cat_against_normal() {
+fn test_local_is_mark_against_ucd_category() {
     for cp in iter_all_chars() {
         assert_eq!(GC::of(cp).is_mark(), is_combining_mark(cp));
     }


### PR DESCRIPTION
Revert of <https://github.com/behnam/rust-unic/pull/105>

Also, add a `![cfg()]` to the integration test, to only perform it when
it matters. Also, this way, we can see if the feature is auto-enabled or
not. (Which is not!)