### PR TITLE
[idna][normal] Add use-ucd-category feature

### DIFF
--- a/unic/Cargo.toml
+++ b/unic/Cargo.toml
@@ -20,8 +20,8 @@ serde = ["unic-bidi/serde"]
 
 [dependencies]
 unic-bidi = { path = "bidi/", version = "0.5.0" }
-unic-idna = { path = "idna/", version = "0.5.0" }
-unic-normal = { path = "normal/", version = "0.5.0" }
+unic-idna = { path = "idna/", version = "0.5.0", features = ["unic-ucd-category"] }
+unic-normal = { path = "normal/", version = "0.5.0", features = ["unic-ucd-category"] }
 unic-ucd = { path = "ucd/", version = "0.5.0" }
 unic-utils = { path = "utils/", version = "0.5.0" }
 

--- a/unic/idna/Cargo.toml
+++ b/unic/idna/Cargo.toml
@@ -23,3 +23,7 @@ unic-normal = { path = "../normal/", version = "0.5.0" }
 unic-ucd-bidi = { path = "../ucd/bidi/", version = "0.5.0" }
 unic-ucd-core = { path = "../ucd/core/", version = "0.5.0" }
 unic-ucd-normal = { path = "../ucd/normal/", version = "0.5.0" }
+
+[features]
+default = []
+unic-ucd-category = ["unic-ucd-normal/unic-ucd-category"]

--- a/unic/normal/Cargo.toml
+++ b/unic/normal/Cargo.toml
@@ -20,3 +20,7 @@ unic-ucd-normal = { path = "../ucd/normal/", version = "0.5.0" }
 
 [dev-dependencies]
 unic-ucd-core = { path = "../ucd/core/", version = "0.5.0" }
+
+[features]
+default = []
+unic-ucd-category = ["unic-ucd-normal/unic-ucd-category"]


### PR DESCRIPTION
`ucd-normal` has the option to use `ucd-category`. Therefore, it makes
sense to enable the feature whenever we know `ucd-category` is
available, which include `unic` proper.

In a larger scope, I'm not sure if we want to go down this path, and may
actually worth it if we just drop the optional feature and always do
that. But, in another hand, it's a good excercise for optional
cross-component dependencies and we can decide later depending on what
other kinds of options we add.