### PR TITLE
[char/range] Add CharRange and CharIter

### DIFF
--- a/unic/char/Cargo.toml
+++ b/unic/char/Cargo.toml
@@ -16,3 +16,4 @@ travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
 unic-char-property = { path = "property/", version = "0.5.0" }
+unic-char-range = { path = "range/", version = "0.5.0" }

--- a/unic/char/range/Cargo.toml
+++ b/unic/char/range/Cargo.toml
@@ -14,5 +14,11 @@ exclude = []
 [features]
 default = []
 
+# Unstable features
+unstable = [ "fused", "trusted-len" ]
+fused = []
+trusted-len = []
+
+
 [badges]
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }

--- a/unic/char/range/Cargo.toml
+++ b/unic/char/range/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
 keywords = ["text", "unicode", "iteration"]
-description = "UNIC - CharRange"
+description = "UNIC - Unicode Characters - Character Range and Iteration"
 categories = ["text-processing"]
 
 # No tests/benches that depends on /data/

--- a/unic/char/range/Cargo.toml
+++ b/unic/char/range/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "unic-char-range"
+version = "0.5.0"
+authors = ["The UNIC Project Developers"]
+repository = "https://github.com/behnam/rust-unic/"
+license = "MIT/Apache-2.0"
+keywords = ["text", "unicode", "iteration"]
+description = "UNIC - CharRange"
+categories = ["text-processing", "iteration"]
+
+# No tests/benches that depends on /data/
+exclude = []
+
+[features]
+default = []
+
+[badges]
+travis-ci = { repository = "behnam/rust-unic", branch = "master" }

--- a/unic/char/range/Cargo.toml
+++ b/unic/char/range/Cargo.toml
@@ -15,7 +15,8 @@ exclude = []
 default = []
 
 # Unstable features
-unstable = [ "fused", "trusted-len" ]
+unstable = [ "exact-size-is-empty", "fused", "trusted-len" ]
+exact-size-is-empty = []
 fused = []
 trusted-len = []
 

--- a/unic/char/range/Cargo.toml
+++ b/unic/char/range/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
 keywords = ["text", "unicode", "iteration"]
 description = "UNIC - CharRange"
-categories = ["text-processing", "iteration"]
+categories = ["text-processing"]
 
 # No tests/benches that depends on /data/
 exclude = []

--- a/unic/char/range/benches/benchmarks.rs
+++ b/unic/char/range/benches/benchmarks.rs
@@ -1,0 +1,17 @@
+#![feature(test)]
+
+extern crate test;
+extern crate unic_char_range;
+
+use std::char;
+use unic_char_range::CharRange;
+
+#[bench]
+fn count(b: &mut test::Bencher) {
+    b.iter(|| CharRange::closed('\0', '\u{10FFFF}').count())
+}
+
+#[bench]
+fn count_baseline(b: &mut test::Bencher) {
+    b.iter(|| (0..0x110000).filter_map(char::from_u32).count())
+}

--- a/unic/char/range/benches/benchmarks.rs
+++ b/unic/char/range/benches/benchmarks.rs
@@ -25,3 +25,8 @@ fn reverse_iteration(b: &mut test::Bencher) {
 fn reverse_iteration_baseline(b: &mut test::Bencher) {
     b.iter(|| (0..0x110000).rev().filter_map(char::from_u32).count())
 }
+
+#[bench]
+fn range_length(b: &mut test::Bencher) {
+    b.iter(|| CharRange::all().len())
+}

--- a/unic/char/range/benches/benchmarks.rs
+++ b/unic/char/range/benches/benchmarks.rs
@@ -13,7 +13,7 @@ fn forward_iteration(b: &mut test::Bencher) {
 
 #[bench]
 fn forward_iteration_baseline(b: &mut test::Bencher) {
-    b.iter(|| (0..0x110000).filter_map(char::from_u32).count())
+    b.iter(|| (0..0x11_0000).filter_map(char::from_u32).count())
 }
 
 #[bench]
@@ -23,7 +23,7 @@ fn reverse_iteration(b: &mut test::Bencher) {
 
 #[bench]
 fn reverse_iteration_baseline(b: &mut test::Bencher) {
-    b.iter(|| (0..0x110000).rev().filter_map(char::from_u32).count())
+    b.iter(|| (0..0x11_0000).rev().filter_map(char::from_u32).count())
 }
 
 #[bench]

--- a/unic/char/range/benches/benchmarks.rs
+++ b/unic/char/range/benches/benchmarks.rs
@@ -7,11 +7,21 @@ use std::char;
 use unic_char_range::CharRange;
 
 #[bench]
-fn count(b: &mut test::Bencher) {
-    b.iter(|| CharRange::closed('\0', '\u{10FFFF}').count())
+fn forward_iteration(b: &mut test::Bencher) {
+    b.iter(|| CharRange::all().count())
 }
 
 #[bench]
-fn count_baseline(b: &mut test::Bencher) {
+fn forward_iteration_baseline(b: &mut test::Bencher) {
     b.iter(|| (0..0x110000).filter_map(char::from_u32).count())
+}
+
+#[bench]
+fn reverse_iteration(b: &mut test::Bencher) {
+    b.iter(|| CharRange::all().rev().count())
+}
+
+#[bench]
+fn reverse_iteration_baseline(b: &mut test::Bencher) {
+    b.iter(|| (0..0x110000).rev().filter_map(char::from_u32).count())
 }

--- a/unic/char/range/benches/benchmarks.rs
+++ b/unic/char/range/benches/benchmarks.rs
@@ -8,7 +8,7 @@ use unic_char_range::CharRange;
 
 #[bench]
 fn forward_iteration(b: &mut test::Bencher) {
-    b.iter(|| CharRange::all().count())
+    b.iter(|| CharRange::all().iter().count())
 }
 
 #[bench]
@@ -18,7 +18,7 @@ fn forward_iteration_baseline(b: &mut test::Bencher) {
 
 #[bench]
 fn reverse_iteration(b: &mut test::Bencher) {
-    b.iter(|| CharRange::all().rev().count())
+    b.iter(|| CharRange::all().iter().rev().count())
 }
 
 #[bench]

--- a/unic/char/range/src/iter.rs
+++ b/unic/char/range/src/iter.rs
@@ -1,0 +1,144 @@
+use std::char;
+use std::ops::Range;
+use {CharRange, step};
+
+const SURROGATE_RANGE: Range<u32> = 0xD800..0xE000;
+
+/// An iterator over a range of unicode code points.
+#[derive(Clone, Debug)]
+pub struct CharIter {
+    /// The lowest uniterated character (inclusive).
+    ///
+    /// Iteration is finished if this is higher than `high`.
+    ///
+    /// # Safety
+    ///
+    /// This is not guaranteed to always be a valid character. Check before using!
+    /// Note that `high` _is_ guaranteed to be a valid character,
+    /// so this will always be a valid character when iteration is not yet finished.
+    low: char,
+
+    /// The highest uniterated character (inclusive).
+    ///
+    /// Iteration is finished if this is lower than `low`.
+    high: char,
+}
+
+impl From<CharRange> for CharIter {
+    fn from(range: CharRange) -> CharIter {
+        CharIter { low: range.low, high: range.high }
+    }
+}
+
+impl From<CharIter> for CharRange {
+    fn from(iter: CharIter) -> CharRange {
+        CharRange { low: iter.low, high: iter.high }
+    }
+}
+
+impl CharIter {
+    #[inline]
+    #[allow(unsafe_code)]
+    // It is always safe to step `self.low` forward because
+    // `self.low` will only be used when less than `self.high`.
+    fn step_forward(&mut self) {
+        self.low = unsafe { step::forward(self.low) }
+    }
+
+    #[inline]
+    #[allow(unsafe_code)]
+    // When stepping `self.high` backward would cause underflow,
+    // step `self.low` forward instead. It will have the same effect --
+    // consuming the last element from the iterator and ending iteration.
+    fn step_backward(&mut self) {
+        if self.high == '\0' {
+            self.low = char::MAX;
+        } else {
+            self.high = unsafe { step::backward(self.high) }
+        }
+    }
+
+    #[inline]
+    /// ExactSizeIterator::is_empty() for stable
+    fn is_finished(&self) -> bool {
+        self.low > self.high
+    }
+}
+
+impl Iterator for CharIter {
+    type Item = char;
+
+    #[inline]
+    fn next(&mut self) -> Option<char> {
+        if self.is_finished() {
+            return None;
+        }
+
+        let ch = self.low;
+        self.step_forward();
+        Some(ch)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+
+    fn last(self) -> Option<char> {
+        if self.is_finished() {
+            None
+        } else {
+            Some(self.high)
+        }
+    }
+
+    fn max(self) -> Option<char> {
+        self.last()
+    }
+
+    fn min(mut self) -> Option<char> {
+        self.next()
+    }
+}
+
+impl DoubleEndedIterator for CharIter {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.is_finished() {
+            None
+        } else {
+            let ch = self.high;
+            self.step_backward();
+            Some(ch)
+        }
+    }
+}
+
+impl ExactSizeIterator for CharIter {
+    fn len(&self) -> usize {
+        if self.is_finished() {
+            return 0;
+        }
+        let naive_range = (self.low as u32)..(self.high as u32 + 1);
+        if naive_range.start <= SURROGATE_RANGE.start && SURROGATE_RANGE.end <= naive_range.end {
+            naive_range.len() - SURROGATE_RANGE.len()
+        } else {
+            naive_range.len()
+        }
+    }
+
+    #[cfg(feature = "exact-size-is-empty")]
+    fn is_empty(&self) -> bool {
+        self.is_finished()
+    }
+}
+
+#[cfg(any(feature = "fused", feature = "trusted-len"))]
+use std::iter;
+
+#[cfg(feature = "fused")]
+impl iter::FusedIterator for CharIter {}
+
+#[allow(unsafe_code)]
+#[cfg(feature = "trusted-len")]
+unsafe impl iter::TrustedLen for CharIter {}

--- a/unic/char/range/src/iter.rs
+++ b/unic/char/range/src/iter.rs
@@ -1,6 +1,6 @@
 use std::char;
 use std::ops::Range;
-use {CharRange, step};
+use {step, CharRange};
 
 const SURROGATE_RANGE: Range<u32> = 0xD800..0xE000;
 
@@ -20,13 +20,19 @@ pub struct CharIter {
 
 impl From<CharRange> for CharIter {
     fn from(range: CharRange) -> CharIter {
-        CharIter { low: range.low, high: range.high }
+        CharIter {
+            low: range.low,
+            high: range.high,
+        }
     }
 }
 
 impl From<CharIter> for CharRange {
     fn from(iter: CharIter) -> CharRange {
-        CharRange { low: iter.low, high: iter.high }
+        CharRange {
+            low: iter.low,
+            high: iter.high,
+        }
     }
 }
 

--- a/unic/char/range/src/iter.rs
+++ b/unic/char/range/src/iter.rs
@@ -5,6 +5,8 @@ use {step, CharRange};
 const SURROGATE_RANGE: Range<u32> = 0xD800..0xE000;
 
 /// An iterator over a range of unicode code points.
+///
+/// Constructed via `CharRange::iter`. See `CharRange` for more information.
 #[derive(Clone, Debug)]
 pub struct CharIter {
     /// The lowest uniterated character (inclusive).

--- a/unic/char/range/src/lib.rs
+++ b/unic/char/range/src/lib.rs
@@ -1,0 +1,31 @@
+//! # Unic - Char - Range
+//!
+//! A simple way to control iteration over a range of characters.
+//!
+//! # Examples
+//!
+//! ```
+//! # #[macro_use] extern crate unic_char_range;
+//! # use unic_char_range::*;
+//!
+//! # fn main() {
+//! for character in chars!('a'=..='z') {
+//!     // character is each character in the lowercase english alphabet in order
+//! }
+//!
+//! for character in CharRange::all() {
+//!     // character is every valid char from lowest codepoint to highest
+//! }
+//! # }
+//! ```
+//!
+#![forbid(bad_style, missing_debug_implementations, unconditional_recursion)]
+#![deny(missing_docs, unsafe_code, unused, future_incompatible)]
+
+const BEFORE_SURROGATE: u32 = 0xD7FF;
+const AFTER_SURROGATE: u32 = 0xE000;
+
+mod range;
+mod step;
+
+pub use range::CharRange;

--- a/unic/char/range/src/lib.rs
+++ b/unic/char/range/src/lib.rs
@@ -18,6 +18,17 @@
 //! # }
 //! ```
 //!
+//! # Features
+//!
+//! None of these features are included by default; they rely on unstable Rust feature gates.
+//!
+//! - `unstable`: enables all features
+//! - `fused`: impl the [`FusedIterator`] contract
+//! - `trusted-len`: impl the [`TrustedLen`] contract
+//!
+//! [`FusedIterator`](https://doc.rust-lang.org/std/iter/trait.FusedIterator.html)
+//! [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html)
+//!
 #![forbid(bad_style, missing_debug_implementations, unconditional_recursion)]
 #![deny(missing_docs, unsafe_code, unused, future_incompatible)]
 #![cfg_attr(feature = "fused", feature(fused))]

--- a/unic/char/range/src/lib.rs
+++ b/unic/char/range/src/lib.rs
@@ -9,7 +9,7 @@
 //! # use unic_char_range::*;
 //!
 //! # fn main() {
-//! for character in chars!('a'=..='z') {
+//! for character in chars!('a'..='z') {
 //!     // character is each character in the lowercase english alphabet in order
 //! }
 //!
@@ -21,9 +21,6 @@
 //!
 #![forbid(bad_style, missing_debug_implementations, unconditional_recursion)]
 #![deny(missing_docs, unsafe_code, unused, future_incompatible)]
-
-const BEFORE_SURROGATE: u32 = 0xD7FF;
-const AFTER_SURROGATE: u32 = 0xE000;
 
 mod range;
 mod step;

--- a/unic/char/range/src/lib.rs
+++ b/unic/char/range/src/lib.rs
@@ -22,6 +22,7 @@
 #![forbid(bad_style, missing_debug_implementations, unconditional_recursion)]
 #![deny(missing_docs, unsafe_code, unused, future_incompatible)]
 
+mod macros;
 mod range;
 mod step;
 

--- a/unic/char/range/src/lib.rs
+++ b/unic/char/range/src/lib.rs
@@ -12,7 +12,7 @@
 //!     // character is each character in the lowercase english alphabet in order
 //! }
 //!
-//! for character in CharRange::all() {
+//! for character in chars!(..) {
 //!     // character is every valid char from lowest codepoint to highest
 //! }
 //! # }

--- a/unic/char/range/src/lib.rs
+++ b/unic/char/range/src/lib.rs
@@ -7,7 +7,6 @@
 //! ```
 //! # #[macro_use] extern crate unic_char_range;
 //! # use unic_char_range::*;
-//!
 //! # fn main() {
 //! for character in chars!('a'..='z') {
 //!     // character is each character in the lowercase english alphabet in order
@@ -21,6 +20,8 @@
 //!
 #![forbid(bad_style, missing_debug_implementations, unconditional_recursion)]
 #![deny(missing_docs, unsafe_code, unused, future_incompatible)]
+#![cfg_attr(feature = "fused", feature(fused))]
+#![cfg_attr(feature = "trusted-len", feature(trusted_len))]
 
 mod macros;
 mod range;

--- a/unic/char/range/src/lib.rs
+++ b/unic/char/range/src/lib.rs
@@ -5,8 +5,8 @@
 //! # Examples
 //!
 //! ```
-//! # #[macro_use] extern crate unic_char_range;
-//! # use unic_char_range::*;
+//! #[macro_use] extern crate unic_char_range;
+//!
 //! # fn main() {
 //! for character in chars!('a'..='z') {
 //!     // character is each character in the lowercase english alphabet in order
@@ -27,9 +27,9 @@
 //! - `fused`: impl the [`FusedIterator`] contract
 //! - `trusted-len`: impl the [`TrustedLen`] contract
 //!
-//! [is_empty](https://doc.rust-lang.org/std/iter/trait.ExactSizeIterator.html#method.is_empty)
-//! [`FusedIterator`](https://doc.rust-lang.org/std/iter/trait.FusedIterator.html)
-//! [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html)
+//! [is_empty]: https://doc.rust-lang.org/std/iter/trait.ExactSizeIterator.html#method.is_empty
+//! [`FusedIterator`]: https://doc.rust-lang.org/std/iter/trait.FusedIterator.html
+//! [`TrustedLen`]: https://doc.rust-lang.org/std/iter/trait.TrustedLen.html
 //!
 #![forbid(bad_style, missing_debug_implementations, unconditional_recursion)]
 #![deny(missing_docs, unsafe_code, unused, future_incompatible)]

--- a/unic/char/range/src/lib.rs
+++ b/unic/char/range/src/lib.rs
@@ -23,19 +23,24 @@
 //! None of these features are included by default; they rely on unstable Rust feature gates.
 //!
 //! - `unstable`: enables all features
+//! - `exact-size-is-empty`: provide a specific impl of [`ExactSizeIterator::is_empty`][is_empty]
 //! - `fused`: impl the [`FusedIterator`] contract
 //! - `trusted-len`: impl the [`TrustedLen`] contract
 //!
+//! [is_empty](https://doc.rust-lang.org/std/iter/trait.ExactSizeIterator.html#method.is_empty)
 //! [`FusedIterator`](https://doc.rust-lang.org/std/iter/trait.FusedIterator.html)
 //! [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html)
 //!
 #![forbid(bad_style, missing_debug_implementations, unconditional_recursion)]
 #![deny(missing_docs, unsafe_code, unused, future_incompatible)]
+#![cfg_attr(feature = "exact-size-is-empty", feature(exact_size_is_empty))]
 #![cfg_attr(feature = "fused", feature(fused))]
 #![cfg_attr(feature = "trusted-len", feature(trusted_len))]
 
 mod macros;
 mod range;
+mod iter;
 mod step;
 
 pub use range::CharRange;
+pub use iter::CharIter;

--- a/unic/char/range/src/macros.rs
+++ b/unic/char/range/src/macros.rs
@@ -6,9 +6,9 @@
 /// ```
 /// # #[macro_use] extern crate unic_char_range;
 /// # fn main() {
-/// chars!('a'..'z'); // Iterate the half open range including 'a' and excluding 'z'
-/// chars!('a'..='z'); // Iterate the closed range including 'a' and including 'z'
-/// chars!(..); // Iterate all characters
+/// chars!('a'..'z'); // The half open range including 'a' and excluding 'z'
+/// chars!('a'..='z'); // The closed range including 'a' and including 'z'
+/// chars!(..); // All characters
 /// # }
 /// ```
 ///

--- a/unic/char/range/src/macros.rs
+++ b/unic/char/range/src/macros.rs
@@ -8,12 +8,18 @@
 /// # fn main() {
 /// chars!('a'..'z'); // Iterate the half open range including 'a' and excluding 'z'
 /// chars!('a'..='z'); // Iterate the closed range including 'a' and including 'z'
+/// chars!(..); // Iterate all characters
 /// # }
 /// ```
 ///
-/// `chars!(..=)` is a constant-time expression, and can be used where such are required,
-/// such as in the initialization of constant data structures.
+/// `chars!('a'..='z')` and `chars!(..)` are constant-time expressions, and can be used
+/// where such are required, such as in the initialization of constant data structures.
+///
+/// Note that because an `expr` capture cannot be followed by a `..`/`..=`,
+/// this macro captures token trees. This means that if you want to pass more than one token,
+/// you must parenthesize it (e.g. `chars!('\0' ..= (char::MAX)`).
 macro_rules! chars {
     ( $low:tt .. $high:tt ) => ( $crate::CharRange { low: $low, high: $high } );
     ( $low:tt ..= $high:tt ) => ( $crate::CharRange::open_right($low, $high) );
+    ( .. ) => ( chars!( '\0' ..= (::std::char::MAX) ) );
 }

--- a/unic/char/range/src/macros.rs
+++ b/unic/char/range/src/macros.rs
@@ -19,7 +19,7 @@
 /// this macro captures token trees. This means that if you want to pass more than one token,
 /// you must parenthesize it (e.g. `chars!('\0' ..= (char::MAX)`).
 macro_rules! chars {
-    ( $low:tt .. $high:tt ) => ( $crate::CharRange { low: $low, high: $high } );
-    ( $low:tt ..= $high:tt ) => ( $crate::CharRange::open_right($low, $high) );
+    ( $low:tt .. $high:tt ) => ( $crate::CharRange::open_right($low, $high) );
+    ( $low:tt ..= $high:tt ) => ( $crate::CharRange { low: $low, high: $high } );
     ( .. ) => ( chars!( '\0' ..= (::std::char::MAX) ) );
 }

--- a/unic/char/range/src/macros.rs
+++ b/unic/char/range/src/macros.rs
@@ -1,0 +1,19 @@
+#[macro_export]
+/// Convenience macro for the initialization of `CharRange`s.
+///
+/// # Syntax
+///
+/// ```
+/// # #[macro_use] extern crate unic_char_range;
+/// # fn main() {
+/// chars!('a'..'z'); // Iterate the half open range including 'a' and excluding 'z'
+/// chars!('a'..='z'); // Iterate the closed range including 'a' and including 'z'
+/// # }
+/// ```
+///
+/// `chars!(..=)` is a constant-time expression, and can be used where such are required,
+/// such as in the initialization of constant data structures.
+macro_rules! chars {
+    ( $low:tt .. $high:tt ) => ( $crate::CharRange { low: $low, high: $high } );
+    ( $low:tt ..= $high:tt ) => ( $crate::CharRange::open_right($low, $high) );
+}

--- a/unic/char/range/src/range.rs
+++ b/unic/char/range/src/range.rs
@@ -1,10 +1,26 @@
+use std::char;
+use std::ops::Range;
 use step;
-use {AFTER_SURROGATE, BEFORE_SURROGATE};
+
+const SURROGATE_RANGE: Range<u32> = 0xD800..0xE000;
 
 /// A range of unicode code points.
 #[derive(Debug)]
 pub struct CharRange {
+    /// The lowest uniterated character.
+    ///
+    /// Iteration is finished if this is higher than `high`.
+    ///
+    /// # Safety
+    ///
+    /// This is not guaranteed to always be a valid character. Check before using!
+    /// Note that `high` _is_ guaranteed to be a valid character,
+    /// so this will always be a valid character when iteration is not yet finished.
     low: char,
+
+    /// The highest uniterated character.
+    ///
+    /// Iteration is finished if this is lower than `low`.
     high: char,
 }
 
@@ -19,24 +35,59 @@ impl CharRange {
     }
 }
 
+impl CharRange {
+    #[inline]
+    #[allow(unsafe_code)]
+    // It is always safe to step `self.low` forward because
+    // it will only be used when less than `self.high`.
+    fn step_forward(&mut self) {
+        self.low = unsafe { step::forward(self.low) }
+    }
+
+    #[inline]
+    #[allow(unsafe_code)]
+    // When stepping `self.high` backward would cause underflow,
+    // step `self.low` forward instead. It will have the same effect --
+    // consuming the last element from the iterator and ending iteration.
+    fn step_backward(&mut self) {
+        if self.high == '\0' {
+            self.step_forward();
+        } else {
+            self.high = unsafe { step::backward(self.high) }
+        }
+    }
+}
+
 impl Iterator for CharRange {
     type Item = char;
 
     #[inline]
-    #[allow(unsafe_code)]
     fn next(&mut self) -> Option<char> {
         if self.low > self.high {
             return None;
         }
 
         let char = self.low;
-        self.low = unsafe { step::forward(self.low) };
+        self.step_forward();
         Some(char)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.len();
         (len, Some(len))
+    }
+}
+
+impl DoubleEndedIterator for CharRange {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.low > self.high {
+            return None;
+        }
+
+        let char = self.high;
+        self.step_backward();
+        Some(char)
     }
 }
 
@@ -48,8 +99,8 @@ impl ExactSizeIterator for CharRange {
         let start = self.low as u32;
         let end = self.high as u32;
         let naive_len = (end - start + 1) as usize;
-        if start <= BEFORE_SURROGATE && end <= AFTER_SURROGATE {
-            naive_len - (AFTER_SURROGATE - BEFORE_SURROGATE - 1) as usize
+        if start <= SURROGATE_RANGE.start && SURROGATE_RANGE.end <= end {
+            naive_len - SURROGATE_RANGE.len() as usize
         } else {
             naive_len
         }

--- a/unic/char/range/src/range.rs
+++ b/unic/char/range/src/range.rs
@@ -5,9 +5,13 @@ use step;
 const SURROGATE_RANGE: Range<u32> = 0xD800..0xE000;
 
 /// A range of unicode code points.
+///
+/// The members of this struct are public for const initialization by `chars!(..=)` only.
+/// They should be considered unstable private API that may change at any time.
+/// If you decide to use them anyway, make sure to note the safety notes.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct CharRange {
-    /// The lowest uniterated character.
+    /// The lowest uniterated character (inclusive).
     ///
     /// Iteration is finished if this is higher than `high`.
     ///
@@ -16,12 +20,14 @@ pub struct CharRange {
     /// This is not guaranteed to always be a valid character. Check before using!
     /// Note that `high` _is_ guaranteed to be a valid character,
     /// so this will always be a valid character when iteration is not yet finished.
-    low: char,
+    #[doc(hidden)]
+    pub low: char,
 
-    /// The highest uniterated character.
+    /// The highest uniterated character (inclusive).
     ///
     /// Iteration is finished if this is lower than `low`.
-    high: char,
+    #[doc(hidden)]
+    pub high: char,
 }
 
 /// Constructors

--- a/unic/char/range/src/range.rs
+++ b/unic/char/range/src/range.rs
@@ -127,6 +127,22 @@ impl Iterator for CharRange {
         let len = self.len();
         (len, Some(len))
     }
+
+    fn last(self) -> Option<char> {
+        if self.low > self.high {
+            None
+        } else {
+            Some(self.high)
+        }
+    }
+
+    fn max(self) -> Option<char> {
+        self.last()
+    }
+
+    fn min(mut self) -> Option<char> {
+        self.next()
+    }
 }
 
 impl DoubleEndedIterator for CharRange {

--- a/unic/char/range/src/range.rs
+++ b/unic/char/range/src/range.rs
@@ -5,7 +5,7 @@ use step;
 const SURROGATE_RANGE: Range<u32> = 0xD800..0xE000;
 
 /// A range of unicode code points.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct CharRange {
     /// The lowest uniterated character.
     ///

--- a/unic/char/range/src/range.rs
+++ b/unic/char/range/src/range.rs
@@ -64,13 +64,17 @@ impl CharRange {
     }
 
     /// Construct a range of characters from bounds.
-    pub fn bound(mut start: Bound<char>, mut stop: Bound<char>) -> CharRange {
-        if start == Bound::Unbounded {
-            start = Bound::Included('\0');
-        }
-        if stop == Bound::Unbounded {
-            stop = Bound::Included(char::MAX);
-        }
+    pub fn bound(start: Bound<char>, stop: Bound<char>) -> CharRange {
+        let start = if start == Bound::Unbounded {
+            Bound::Included('\0')
+        } else {
+            start
+        };
+        let stop = if stop == Bound::Unbounded {
+            Bound::Included(char::MAX)
+        } else {
+            stop
+        };
         match (start, stop) {
             (Bound::Included(start), Bound::Included(stop)) => CharRange::closed(start, stop),
             (Bound::Excluded(start), Bound::Excluded(stop)) => CharRange::open(start, stop),

--- a/unic/char/range/src/range.rs
+++ b/unic/char/range/src/range.rs
@@ -1,4 +1,5 @@
 use std::char;
+use std::collections::Bound;
 use std::ops::Range;
 use step;
 
@@ -60,6 +61,23 @@ impl CharRange {
         range.step_forward();
         range.step_backward();
         range
+    }
+
+    /// Construct a range of characters from bounds.
+    pub fn bound(mut start: Bound<char>, mut stop: Bound<char>) -> CharRange {
+        if start == Bound::Unbounded {
+            start = Bound::Included('\0');
+        }
+        if stop == Bound::Unbounded {
+            stop = Bound::Included(char::MAX);
+        }
+        match (start, stop) {
+            (Bound::Included(start), Bound::Included(stop)) => CharRange::closed(start, stop),
+            (Bound::Excluded(start), Bound::Excluded(stop)) => CharRange::open(start, stop),
+            (Bound::Included(start), Bound::Excluded(stop)) => CharRange::open_right(start, stop),
+            (Bound::Excluded(start), Bound::Included(stop)) => CharRange::open_left(start, stop),
+            (Bound::Unbounded, _) | (_, Bound::Unbounded) => unreachable!(),
+        }
     }
 
     /// Construct a range over all characters.

--- a/unic/char/range/src/range.rs
+++ b/unic/char/range/src/range.rs
@@ -151,7 +151,7 @@ impl ExactSizeIterator for CharRange {
         let end = self.high as u32;
         let naive_len = self.high as usize - self.low as usize + 1;
         if start <= SURROGATE_RANGE.start && SURROGATE_RANGE.end <= end {
-            naive_len - SURROGATE_RANGE.len() as usize
+            naive_len - SURROGATE_RANGE.len()
         } else {
             naive_len
         }

--- a/unic/char/range/src/range.rs
+++ b/unic/char/range/src/range.rs
@@ -94,9 +94,9 @@ impl Iterator for CharRange {
             return None;
         }
 
-        let char = self.low;
+        let ch = self.low;
         self.step_forward();
-        Some(char)
+        Some(ch)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -112,9 +112,9 @@ impl DoubleEndedIterator for CharRange {
             return None;
         }
 
-        let char = self.high;
+        let ch = self.high;
         self.step_backward();
-        Some(char)
+        Some(ch)
     }
 }
 
@@ -125,7 +125,7 @@ impl ExactSizeIterator for CharRange {
         }
         let start = self.low as u32;
         let end = self.high as u32;
-        let naive_len = (end - start + 1) as usize;
+        let naive_len = self.high as usize - self.low as usize + 1;
         if start <= SURROGATE_RANGE.start && SURROGATE_RANGE.end <= end {
             naive_len - SURROGATE_RANGE.len() as usize
         } else {

--- a/unic/char/range/src/range.rs
+++ b/unic/char/range/src/range.rs
@@ -157,3 +157,13 @@ impl ExactSizeIterator for CharRange {
         }
     }
 }
+
+#[cfg(any(feature = "fused", feature = "trusted-len"))]
+use std::iter;
+
+#[cfg(feature = "fused")]
+impl iter::FusedIterator for CharRange {}
+
+#[allow(unsafe_code)]
+#[cfg(feature = "trusted-len")]
+unsafe impl iter::TrustedLen for CharRange {}

--- a/unic/char/range/src/range.rs
+++ b/unic/char/range/src/range.rs
@@ -26,12 +26,39 @@ pub struct CharRange {
 
 /// Constructors
 impl CharRange {
-    /// Construct a closed range of characters
+    /// Construct a closed range of characters.
     pub fn closed(start: char, stop: char) -> CharRange {
         CharRange {
             low: start,
             high: stop,
         }
+    }
+
+    /// Construct a half open (right) range of characters.
+    pub fn open_right(start: char, stop: char) -> CharRange {
+        let mut range = CharRange::closed(start, stop);
+        range.step_backward();
+        range
+    }
+
+    /// Construct a half open (left) range of characters.
+    pub fn open_left(start: char, stop: char) -> CharRange {
+        let mut range = CharRange::closed(start, stop);
+        range.step_forward();
+        range
+    }
+
+    /// Construct a fully open range of characters.
+    pub fn open(start: char, stop: char) -> CharRange {
+        let mut range = CharRange::closed(start, stop);
+        range.step_forward();
+        range.step_backward();
+        range
+    }
+
+    /// Construct a range over all characters.
+    pub fn all() -> CharRange {
+        CharRange::closed('\0', char::MAX)
     }
 }
 
@@ -39,7 +66,7 @@ impl CharRange {
     #[inline]
     #[allow(unsafe_code)]
     // It is always safe to step `self.low` forward because
-    // it will only be used when less than `self.high`.
+    // `self.low` will only be used when less than `self.high`.
     fn step_forward(&mut self) {
         self.low = unsafe { step::forward(self.low) }
     }

--- a/unic/char/range/src/range.rs
+++ b/unic/char/range/src/range.rs
@@ -1,0 +1,56 @@
+use step;
+use {AFTER_SURROGATE, BEFORE_SURROGATE};
+
+/// A range of unicode code points.
+#[derive(Debug)]
+pub struct CharRange {
+    low: char,
+    high: char,
+}
+
+/// Constructors
+impl CharRange {
+    /// Construct a closed range of characters
+    pub fn closed(start: char, stop: char) -> CharRange {
+        CharRange {
+            low: start,
+            high: stop,
+        }
+    }
+}
+
+impl Iterator for CharRange {
+    type Item = char;
+
+    #[allow(unsafe_code)]
+    fn next(&mut self) -> Option<char> {
+        if self.low > self.high {
+            return None;
+        }
+
+        let char = self.low;
+        self.low = unsafe { step::forward(self.low) };
+        Some(char)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+impl ExactSizeIterator for CharRange {
+    fn len(&self) -> usize {
+        if self.low > self.high {
+            return 0;
+        }
+        let start = self.low as u32;
+        let end = self.high as u32;
+        let naive_len = (end - start + 1) as usize;
+        if start <= BEFORE_SURROGATE && end <= AFTER_SURROGATE {
+            naive_len - (AFTER_SURROGATE - BEFORE_SURROGATE - 1) as usize
+        } else {
+            naive_len
+        }
+    }
+}

--- a/unic/char/range/src/range.rs
+++ b/unic/char/range/src/range.rs
@@ -22,6 +22,7 @@ impl CharRange {
 impl Iterator for CharRange {
     type Item = char;
 
+    #[inline]
     #[allow(unsafe_code)]
     fn next(&mut self) -> Option<char> {
         if self.low > self.high {

--- a/unic/char/range/src/range.rs
+++ b/unic/char/range/src/range.rs
@@ -29,6 +29,16 @@ impl CharRange {
     /// Construct a closed range of characters.
     ///
     /// If `stop` is ordered before `start`, the resulting range will be empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use unic_char_range::*;
+    /// assert_eq!(
+    ///     CharRange::closed('a', 'd').iter().collect::<Vec<_>>(),
+    ///     vec!['a', 'b', 'c', 'd']
+    /// )
+    /// ```
     pub fn closed(start: char, stop: char) -> CharRange {
         CharRange {
             low: start,
@@ -39,6 +49,16 @@ impl CharRange {
     /// Construct a half open (right) range of characters.
     ///
     /// If `stop` is ordered before `start`, the resulting range will be empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use unic_char_range::*;
+    /// assert_eq!(
+    ///     CharRange::open_right('a', 'd').iter().collect::<Vec<_>>(),
+    ///     vec!['a', 'b', 'c']
+    /// )
+    /// ```
     pub fn open_right(start: char, stop: char) -> CharRange {
         let mut iter = CharRange::closed(start, stop).iter();
         let _ = iter.next_back();
@@ -48,6 +68,16 @@ impl CharRange {
     /// Construct a half open (left) range of characters.
     ///
     /// If `stop` is ordered before `start`, the resulting range will be empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use unic_char_range::*;
+    /// assert_eq!(
+    ///     CharRange::open_left('a', 'd').iter().collect::<Vec<_>>(),
+    ///     vec!['b', 'c', 'd']
+    /// )
+    /// ```
     pub fn open_left(start: char, stop: char) -> CharRange {
         let mut iter = CharRange::closed(start, stop).iter();
         let _ = iter.next();
@@ -57,6 +87,16 @@ impl CharRange {
     /// Construct a fully open range of characters.
     ///
     /// If `stop` is ordered before `start`, the resulting range will be empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use unic_char_range::*;
+    /// assert_eq!(
+    ///     CharRange::open('a', 'd').iter().collect::<Vec<_>>(),
+    ///     vec!['b', 'c']
+    /// )
+    /// ```
     pub fn open(start: char, stop: char) -> CharRange {
         let mut iter = CharRange::closed(start, stop).iter();
         let _ = iter.next();

--- a/unic/char/range/src/range.rs
+++ b/unic/char/range/src/range.rs
@@ -7,15 +7,20 @@ use CharIter;
 /// The most idiomatic way to construct this range is through the use of the `chars!` macro:
 ///
 /// ```
-/// # #[macro_use] extern crate unic_char_range;
-/// # use unic_char_range::*;
+/// #[macro_use] extern crate unic_char_range;
+/// use unic_char_range::CharRange;
+///
 /// # fn main() {
 /// assert_eq!(chars!('a'..='z'), CharRange::closed('a', 'z'));
 /// assert_eq!(chars!('a'..'z'), CharRange::open_right('a', 'z'));
 /// assert_eq!(chars!(..), CharRange::all());
 /// # }
 /// ```
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+///
+/// If constructed in reverse order, such that `self.high` is ordered before `self.low`,
+/// the range is empty. If you want to iterate in decreasing order, use `.iter().rev()`.
+/// All empty ranges are considered equal no matter the internal state.
+#[derive(Copy, Clone, Debug, Eq)]
 pub struct CharRange {
     /// The lowest character in this range (inclusive).
     pub low: char,
@@ -48,8 +53,6 @@ impl CharRange {
 
     /// Construct a half open (right) range of characters.
     ///
-    /// If `stop` is ordered before `start`, the resulting range will be empty.
-    ///
     /// # Example
     ///
     /// ```
@@ -66,8 +69,6 @@ impl CharRange {
     }
 
     /// Construct a half open (left) range of characters.
-    ///
-    /// If `stop` is ordered before `start`, the resulting range will be empty.
     ///
     /// # Example
     ///
@@ -86,8 +87,6 @@ impl CharRange {
 
     /// Construct a fully open range of characters.
     ///
-    /// If `stop` is ordered before `start`, the resulting range will be empty.
-    ///
     /// # Example
     ///
     /// ```
@@ -105,8 +104,6 @@ impl CharRange {
     }
 
     /// Construct a range of characters from bounds.
-    ///
-    /// If `stop` is ordered before `start`, the resulting range will be empty.
     pub fn bound(start: Bound<char>, stop: Bound<char>) -> CharRange {
         let start = if start == Bound::Unbounded {
             Bound::Included('\0')
@@ -156,6 +153,11 @@ impl CharRange {
         self.iter().len()
     }
 
+    /// Is this range empty?
+    pub fn is_empty(&self) -> bool {
+        self.low > self.high
+    }
+
     /// Create an iterator over this range.
     pub fn iter(&self) -> CharIter {
         (*self).into()
@@ -168,5 +170,11 @@ impl IntoIterator for CharRange {
 
     fn into_iter(self) -> CharIter {
         self.iter()
+    }
+}
+
+impl PartialEq<CharRange> for CharRange {
+    fn eq(&self, other: &CharRange) -> bool {
+        (self.is_empty() && other.is_empty()) || (self.low == other.low && self.high == other.high)
     }
 }

--- a/unic/char/range/src/range.rs
+++ b/unic/char/range/src/range.rs
@@ -109,6 +109,24 @@ impl CharRange {
     }
 }
 
+impl CharRange {
+    /// Does this range include a character?
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use unic_char_range::CharRange;
+    /// assert!(   CharRange::closed('a', 'g').contains('d'));
+    /// assert!( ! CharRange::closed('a', 'g').contains('z'));
+    ///
+    /// assert!( ! CharRange:: open ('a', 'a').contains('a'));
+    /// assert!( ! CharRange::closed('z', 'a').contains('g'));
+    /// ```
+    pub fn contains(&self, ch: char) -> bool {
+        self.low <= ch && ch <= self.high
+    }
+}
+
 impl Iterator for CharRange {
     type Item = char;
 

--- a/unic/char/range/src/step.rs
+++ b/unic/char/range/src/step.rs
@@ -10,11 +10,11 @@ const AFTER_SURROGATE: char = '\u{E000}';
 /// # Safety
 ///
 /// If the given character is `char::MAX`, the return value is not a valid character.
-pub unsafe fn forward(c: char) -> char {
-    if c == BEFORE_SURROGATE {
+pub unsafe fn forward(ch: char) -> char {
+    if ch == BEFORE_SURROGATE {
         AFTER_SURROGATE
     } else {
-        char::from_u32_unchecked(c as u32 + 1)
+        char::from_u32_unchecked(ch as u32 + 1)
     }
 }
 
@@ -26,10 +26,10 @@ pub unsafe fn forward(c: char) -> char {
 ///
 /// If the given character is `'\0'`, this will cause an underflow.
 /// (Thus, it will panic in debug mode, undefined behavior in release mode.)
-pub unsafe fn backward(c: char) -> char {
-    if c == AFTER_SURROGATE {
+pub unsafe fn backward(ch: char) -> char {
+    if ch == AFTER_SURROGATE {
         BEFORE_SURROGATE
     } else {
-        char::from_u32_unchecked(c as u32 - 1)
+        char::from_u32_unchecked(ch as u32 - 1)
     }
 }

--- a/unic/char/range/src/step.rs
+++ b/unic/char/range/src/step.rs
@@ -27,9 +27,9 @@ pub unsafe fn forward(c: char) -> char {
 /// If the given character is `'\0'`, this will cause an underflow.
 /// (Thus, it will panic in debug mode, undefined behavior in release mode.)
 pub unsafe fn backward(c: char) -> char {
-    if c == BEFORE_SURROGATE {
-        AFTER_SURROGATE
+    if c == AFTER_SURROGATE {
+        BEFORE_SURROGATE
     } else {
-        char::from_u32_unchecked(c as u32 + 1)
+        char::from_u32_unchecked(c as u32 - 1)
     }
 }

--- a/unic/char/range/src/step.rs
+++ b/unic/char/range/src/step.rs
@@ -1,14 +1,35 @@
 use std::char;
-use {AFTER_SURROGATE, BEFORE_SURROGATE};
 
-#[inline(always)]
+const BEFORE_SURROGATE: char = '\u{D7FF}';
+const AFTER_SURROGATE: char = '\u{E000}';
+
+#[inline]
 #[allow(unsafe_code)]
+/// Step a character one step towards `char::MAX`.
+///
+/// # Safety
+///
+/// If the given character is `char::MAX`, the return value is not a valid character.
 pub unsafe fn forward(c: char) -> char {
-    let old_point = c as u32;
-    let new_point = if old_point == BEFORE_SURROGATE {
+    if c == BEFORE_SURROGATE {
         AFTER_SURROGATE
     } else {
-        old_point + 1
-    };
-    char::from_u32_unchecked(new_point)
+        char::from_u32_unchecked(c as u32 + 1)
+    }
+}
+
+#[inline]
+#[allow(unsafe_code)]
+/// Step a character one step towards `'\0'`.
+///
+/// # Safety
+///
+/// If the given character is `'\0'`, this will cause an underflow.
+/// (Thus, it will panic in debug mode, undefined behavior in release mode.)
+pub unsafe fn backward(c: char) -> char {
+    if c == BEFORE_SURROGATE {
+        AFTER_SURROGATE
+    } else {
+        char::from_u32_unchecked(c as u32 + 1)
+    }
 }

--- a/unic/char/range/src/step.rs
+++ b/unic/char/range/src/step.rs
@@ -1,0 +1,14 @@
+use std::char;
+use {AFTER_SURROGATE, BEFORE_SURROGATE};
+
+#[inline(always)]
+#[allow(unsafe_code)]
+pub unsafe fn forward(c: char) -> char {
+    let old_point = c as u32;
+    let new_point = if old_point == BEFORE_SURROGATE {
+        AFTER_SURROGATE
+    } else {
+        old_point + 1
+    };
+    char::from_u32_unchecked(new_point)
+}

--- a/unic/char/range/tests/iter_tests.rs
+++ b/unic/char/range/tests/iter_tests.rs
@@ -1,6 +1,6 @@
 extern crate unic_char_range;
 
-use std::{char, u32, vec};
+use std::{char, vec, u32};
 use unic_char_range::CharRange;
 
 fn all_chars() -> vec::IntoIter<char> {

--- a/unic/char/range/tests/iter_tests.rs
+++ b/unic/char/range/tests/iter_tests.rs
@@ -1,0 +1,62 @@
+extern crate unic_char_range;
+
+use std::{char, u32, vec};
+use unic_char_range::CharRange;
+
+fn all_chars() -> vec::IntoIter<char> {
+    (u32::MIN..u32::MAX)
+        .take_while(|&u| u <= char::MAX as u32)
+        .filter_map(char::from_u32)
+        .collect::<Vec<_>>()
+        .into_iter()
+}
+
+#[test]
+fn iter_all_chars() {
+    assert!(CharRange::all().eq(all_chars()))
+}
+
+#[test]
+fn iter_all_chars_rev() {
+    assert!(CharRange::all().rev().eq(all_chars().rev()))
+}
+
+#[test]
+fn iter_all_chars_mixed_next_back() {
+    let mut custom = CharRange::all();
+    let mut simple = all_chars();
+    while let Some(custom_char) = custom.next() {
+        assert_eq!(Some(custom_char), simple.next());
+        assert_eq!(custom.next_back(), simple.next_back());
+    }
+    assert_eq!(None, simple.next());
+}
+
+#[test]
+fn iter_fused() {
+    let mut iter = CharRange::all();
+    let mut fused = all_chars().fuse();
+    assert!(iter.by_ref().eq(fused.by_ref()));
+    for _ in 0..100 {
+        assert_eq!(iter.next(), fused.next());
+    }
+}
+
+#[test]
+fn iter_exact_trusted_len() {
+    fn assert_presents_right_len<I: ExactSizeIterator>(iter: &I, len: usize) {
+        assert_eq!(iter.len(), len);
+        assert_eq!(iter.size_hint(), (len, Some(len)));
+    }
+
+    let mut iter = CharRange::all();
+    let mut predicted_length = iter.len();
+    assert_eq!(predicted_length, all_chars().len());
+
+    while let Some(_) = iter.next() {
+        predicted_length -= 1;
+        assert_presents_right_len(&iter, predicted_length);
+    }
+
+    assert_presents_right_len(&iter, 0);
+}

--- a/unic/char/range/tests/iter_tests.rs
+++ b/unic/char/range/tests/iter_tests.rs
@@ -13,17 +13,17 @@ fn all_chars() -> vec::IntoIter<char> {
 
 #[test]
 fn iter_all_chars() {
-    assert!(CharRange::all().eq(all_chars()))
+    assert!(CharRange::all().iter().eq(all_chars()))
 }
 
 #[test]
 fn iter_all_chars_rev() {
-    assert!(CharRange::all().rev().eq(all_chars().rev()))
+    assert!(CharRange::all().iter().rev().eq(all_chars().rev()))
 }
 
 #[test]
 fn iter_all_chars_mixed_next_back() {
-    let mut custom = CharRange::all();
+    let mut custom = CharRange::all().iter();
     let mut simple = all_chars();
     while let Some(custom_char) = custom.next() {
         assert_eq!(Some(custom_char), simple.next());
@@ -34,7 +34,7 @@ fn iter_all_chars_mixed_next_back() {
 
 #[test]
 fn iter_fused() {
-    let mut iter = CharRange::all();
+    let mut iter = CharRange::all().iter();
     let mut fused = all_chars().fuse();
     assert!(iter.by_ref().eq(fused.by_ref()));
     for _ in 0..100 {
@@ -49,7 +49,7 @@ fn iter_exact_trusted_len() {
         assert_eq!(iter.size_hint(), (len, Some(len)));
     }
 
-    let mut iter = CharRange::all();
+    let mut iter = CharRange::all().iter();
     let mut predicted_length = iter.len();
     assert_eq!(predicted_length, all_chars().len());
 


### PR DESCRIPTION
The first half of adressing #91.
Closes #111, this manner of attack is better than it.

This PR only has one type, `CharRange`. It is effectively `std::ops::RangeInclusive` translated to characters. The matter of construction is handled by both half-open and closed constructors offered and a macro to allow for `'a'..='z'` syntax.