### PR TITLE
[char/property] Add CharProperty trait

### DIFF
--- a/unic/char/property/Cargo.toml
+++ b/unic/char/property/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
 keywords = ["text", "unicode", "character-property"]
-description = "UNIC - Unicode Characters - Character Property"
+description = "UNIC - Unicode Characters - Character Property taxonomy, contracts and build macros"
 categories = ["text-processing", "parsing"]
 
 # No tests/benches that depends on /data/

--- a/unic/char/property/src/domain.rs
+++ b/unic/char/property/src/domain.rs
@@ -16,6 +16,19 @@ use std::fmt::{Debug, Display};
 use std::hash::Hash;
 
 
+/// A Character Property, defined for some or all Unicode characters.
+pub trait CharProperty: PartialCharProperty {
+    /// Get property abbreviated name
+    fn prop_abbr_name() -> &'static str;
+
+    /// Get property long name
+    fn prop_long_name() -> &'static str;
+
+    /// Get property human-readable name
+    fn prop_human_name() -> &'static str;
+}
+
+
 /// A Character Property defined for some characters.
 ///
 /// Examples: *Decomposition_Type*, *Numeric_Type*
@@ -30,6 +43,8 @@ pub trait PartialCharProperty: Copy + Debug + Display + Eq + Hash {
 /// Examples: *Age*, *Name*, *General_Category*, *Bidi_Class*
 // Because of rustc bug, we cannot rely on inheritance for the moment.
 // See: <https://github.com/rust-lang/rust/issues/43777>
+// See: <https://github.com/rust-lang/rust/issues/43784>
+// TODO: Drop extra super-traits after the bugs are fixed.
 //pub trait CompleteCharProperty: PartialCharProperty + Default {
 pub trait CompleteCharProperty
     : PartialCharProperty + Copy + Debug + Display + Eq + Hash + Default {

--- a/unic/char/property/src/lib.rs
+++ b/unic/char/property/src/lib.rs
@@ -37,5 +37,5 @@ mod range;
 mod macros;
 
 
-pub use self::domain::{CompleteCharProperty, PartialCharProperty};
+pub use self::domain::{CharProperty, CompleteCharProperty, PartialCharProperty};
 pub use self::range::{EnumeratedCharProperty, NumericCharProperty, NumericCharPropertyValue};

--- a/unic/char/property/src/macros.rs
+++ b/unic/char/property/src/macros.rs
@@ -41,7 +41,14 @@
 ///     pub mod long_names for long;
 /// }
 ///
-/// // We also need to impl `PartialCharProperty` or `CompleteCharProperty` manually.
+/// // We also need to impl `CharProperty`, and `PartialCharProperty` or `CompleteCharProperty`
+/// // manually.
+/// # // TODO: impl CharProperty by the macro.
+/// # impl unic_char_property::CharProperty for MyProp {
+/// #     fn prop_abbr_name() -> &'static str { "myprop" }
+/// #     fn prop_long_name() -> &'static str { "MyProp" }
+/// #     fn prop_human_name() -> &'static str { "MyProp" }
+/// # }
 /// # impl unic_char_property::PartialCharProperty for MyProp {
 /// #     fn of(_: char) -> Option<Self> { None }
 /// # }

--- a/unic/char/property/src/range.rs
+++ b/unic/char/property/src/range.rs
@@ -12,7 +12,7 @@
 //! Taxonomy and contracts for character property types: property range.
 
 
-use super::PartialCharProperty;
+use super::CharProperty;
 
 
 // == Enumerated/Catalog Types ==
@@ -24,7 +24,7 @@ use super::PartialCharProperty;
 /// Usage Note: If the property is of type *Catalog*, it's recommended to (in some way) mark the
 /// type as *non-exhaustive*, so that adding new variants to the `enum` type won't result in API
 /// breakage.
-pub trait EnumeratedCharProperty: Sized + PartialCharProperty {
+pub trait EnumeratedCharProperty: Sized + CharProperty {
     /// Exhaustive list of all property values.
     fn all_values() -> &'static [Self];
 
@@ -44,8 +44,7 @@ impl NumericCharPropertyValue for u8 {}
 /// A Character Property with numeric values.
 ///
 /// Examples: *Numeric_Value*, *Canonical_Combining_Class*
-pub trait NumericCharProperty<Value: NumericCharPropertyValue>
-    : PartialCharProperty {
+pub trait NumericCharProperty<Value: NumericCharPropertyValue>: CharProperty {
     /// Get numeric value for character property value
     fn number(&self) -> Value;
 }

--- a/unic/char/property/tests/macro_tests.rs
+++ b/unic/char/property/tests/macro_tests.rs
@@ -13,7 +13,7 @@
 extern crate unic_char_property;
 
 
-use unic_char_property::EnumeratedCharProperty;
+use unic_char_property::{CharProperty, PartialCharProperty};
 
 
 char_property! {
@@ -43,7 +43,21 @@ char_property! {
 }
 
 
-impl unic_char_property::PartialCharProperty for MyProp {
+impl CharProperty for MyProp {
+    fn prop_abbr_name() -> &'static str {
+        "myprop"
+    }
+
+    fn prop_long_name() -> &'static str {
+        "MyProp"
+    }
+
+    fn prop_human_name() -> &'static str {
+        "MyProp"
+    }
+}
+
+impl PartialCharProperty for MyProp {
     fn of(_: char) -> Option<Self> {
         None
     }
@@ -52,6 +66,8 @@ impl unic_char_property::PartialCharProperty for MyProp {
 
 #[test]
 fn basic_macro_use() {
+    use unic_char_property::EnumeratedCharProperty;
+
     assert_eq!(MyProp::AbbrVariant, abbr_names::AV);
     assert_eq!(MyProp::LongVariant, abbr_names::LV);
     assert_eq!(MyProp::DisplayVariant, abbr_names::DV);
@@ -76,6 +92,7 @@ fn basic_macro_use() {
 #[test]
 fn fromstr_ignores_case() {
     use abbr_names::LV;
+
     assert_eq!("long_variant".parse(), Ok(LV));
     assert_eq!("lOnG_vArIaNt".parse(), Ok(LV));
     assert_eq!("LoNg_VaRiAnT".parse(), Ok(LV));

--- a/unic/src/lib.rs
+++ b/unic/src/lib.rs
@@ -111,10 +111,10 @@
 //! ```
 
 pub extern crate unic_bidi as bidi;
+pub extern crate unic_char as char;
 pub extern crate unic_idna as idna;
 pub extern crate unic_normal as normal;
 pub extern crate unic_ucd as ucd;
-pub extern crate unic_char as char;
 
 /// The [Unicode version](http://www.unicode.org/versions/) of data
 pub use ucd::UNICODE_VERSION;

--- a/unic/ucd/age/src/age.rs
+++ b/unic/ucd/age/src/age.rs
@@ -13,7 +13,7 @@ use std::fmt;
 
 pub use unic_ucd_core::UnicodeVersion;
 use unic_utils::CharDataTable;
-use unic_char_property::CompleteCharProperty;
+use unic_char_property::{CharProperty, CompleteCharProperty};
 
 
 /// Represents values of the Unicode character property
@@ -39,6 +39,21 @@ pub enum Age {
 
     /// Unassigned Unicode Code Point (can be assigned in future).
     Unassigned, // Unassigned is older (larger) than any age
+}
+
+
+impl CharProperty for Age {
+    fn prop_abbr_name() -> &'static str {
+        "age"
+    }
+
+    fn prop_long_name() -> &'static str {
+        "Age"
+    }
+
+    fn prop_human_name() -> &'static str {
+        "Age"
+    }
 }
 
 

--- a/unic/ucd/bidi/src/bidi_class.rs
+++ b/unic/ucd/bidi/src/bidi_class.rs
@@ -13,7 +13,7 @@
 use std::fmt;
 
 use unic_utils::CharDataTable;
-use unic_char_property::{CompleteCharProperty, EnumeratedCharProperty};
+use unic_char_property::{CharProperty, CompleteCharProperty, EnumeratedCharProperty};
 
 
 /// Represents the Unicode character
@@ -49,6 +49,21 @@ pub enum BidiClass {
     SegmentSeparator,
     WhiteSpace,
     // [UNIC_UPDATE_ON_UNICODE_UPDATE] Source: `tables/bidi_class_type.rsv`
+}
+
+
+impl CharProperty for BidiClass {
+    fn prop_abbr_name() -> &'static str {
+        "bc"
+    }
+
+    fn prop_long_name() -> &'static str {
+        "Bidi_Class"
+    }
+
+    fn prop_human_name() -> &'static str {
+        "Bidi Class"
+    }
 }
 
 

--- a/unic/ucd/category/src/category.rs
+++ b/unic/ucd/category/src/category.rs
@@ -12,7 +12,7 @@
 use std::fmt;
 
 use unic_utils::CharDataTable;
-use unic_char_property::{CompleteCharProperty, EnumeratedCharProperty};
+use unic_char_property::{CharProperty, CompleteCharProperty, EnumeratedCharProperty};
 
 
 /// Represents the Unicode Character
@@ -83,6 +83,21 @@ pub enum GeneralCategory {
     PrivateUse,
     /// Unassigned (Short form: `Cn`)
     Unassigned,
+}
+
+
+impl CharProperty for GeneralCategory {
+    fn prop_abbr_name() -> &'static str {
+        "gc"
+    }
+
+    fn prop_long_name() -> &'static str {
+        "General_Category"
+    }
+
+    fn prop_human_name() -> &'static str {
+        "General Category"
+    }
 }
 
 

--- a/unic/ucd/normal/src/canonical_combining_class.rs
+++ b/unic/ucd/normal/src/canonical_combining_class.rs
@@ -18,7 +18,7 @@
 use std::fmt;
 
 use unic_utils::CharDataTable;
-use unic_char_property::{CompleteCharProperty, NumericCharProperty};
+use unic_char_property::{CharProperty, CompleteCharProperty, NumericCharProperty};
 
 
 /// Represents *Canonical_Combining_Class* property of a Unicode character.
@@ -26,6 +26,21 @@ use unic_char_property::{CompleteCharProperty, NumericCharProperty};
 /// * <http://unicode.org/reports/tr44/#Canonical_Combining_Class>
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct CanonicalCombiningClass(u8);
+
+
+impl CharProperty for CanonicalCombiningClass {
+    fn prop_abbr_name() -> &'static str {
+        "ccc"
+    }
+
+    fn prop_long_name() -> &'static str {
+        "Canonical_Combining_Class"
+    }
+
+    fn prop_human_name() -> &'static str {
+        "Canonical Combining Class"
+    }
+}
 
 
 impl CompleteCharProperty for CanonicalCombiningClass {

--- a/unic/ucd/normal/src/decomposition_type.rs
+++ b/unic/ucd/normal/src/decomposition_type.rs
@@ -15,7 +15,7 @@
 use std::fmt;
 
 use unic_utils::CharDataTable;
-use unic_char_property::{EnumeratedCharProperty, PartialCharProperty};
+use unic_char_property::{CharProperty, EnumeratedCharProperty, PartialCharProperty};
 
 use composition::{canonical_decomposition, COMPATIBILITY_DECOMPOSITION_MAPPING};
 use hangul;
@@ -46,6 +46,21 @@ pub enum DecompositionType {
     Super,
     Vertical,
     Wide,
+}
+
+
+impl CharProperty for DecompositionType {
+    fn prop_abbr_name() -> &'static str {
+        "dt"
+    }
+
+    fn prop_long_name() -> &'static str {
+        "Decomposition_Type"
+    }
+
+    fn prop_human_name() -> &'static str {
+        "Decomposition Type"
+    }
 }
 
 


### PR DESCRIPTION
Add `CharProperty` trait as the core main contract for Character
Property definition, which in return requires defining the domain in
which the property is defined.

We should expand `char_property!` macro to accept these values and
implement the trait internally.

Also, we can see if we want to also enforce choosing a range for the
property. At this moment, `Age` yet doesn't have a contract trait.