### PR TITLE
[char/property] Add long_name()/human_name() to EnumeratedCharProperty

### DIFF
--- a/unic/char/property/src/macros.rs
+++ b/unic/char/property/src/macros.rs
@@ -369,6 +369,14 @@ macro_rules! __char_property_internal {
                 }
             }
 
+            fn long_name(&self) -> &'static str {
+                "FIXME"
+            }
+
+            fn human_name(&self) -> &'static str {
+                "FIXME"
+            }
+
             fn all_values() -> &'static [$name] {
                 const VALUES: &[$name] = &[
                     $($name::$variant,)+

--- a/unic/char/property/src/property.rs
+++ b/unic/char/property/src/property.rs
@@ -46,7 +46,7 @@ pub trait PartialCharProperty: Copy {
 // See: <https://github.com/rust-lang/rust/issues/43784>
 // TODO: Drop extra super-traits after the bugs are fixed.
 //pub trait CompleteCharProperty: PartialCharProperty + Default {
-pub trait CompleteCharProperty : PartialCharProperty + Copy + Default {
+pub trait CompleteCharProperty: PartialCharProperty + Copy + Default {
     /// The property value for the character.
     fn of(ch: char) -> Self;
 }

--- a/unic/char/property/src/property.rs
+++ b/unic/char/property/src/property.rs
@@ -18,13 +18,13 @@ use std::hash::Hash;
 
 /// A Character Property, defined for some or all Unicode characters.
 pub trait CharProperty: PartialCharProperty + Debug + Display + Eq + Hash {
-    /// Get property abbreviated name
+    /// The *abbreviated name* of the property.
     fn prop_abbr_name() -> &'static str;
 
-    /// Get property long name
+    /// The *long name* of the property.
     fn prop_long_name() -> &'static str;
 
-    /// Get property human-readable name
+    /// The *human-readable* name of the property.
     fn prop_human_name() -> &'static str;
 }
 
@@ -33,7 +33,7 @@ pub trait CharProperty: PartialCharProperty + Debug + Display + Eq + Hash {
 ///
 /// Examples: *Decomposition_Type*, *Numeric_Type*
 pub trait PartialCharProperty: Copy {
-    /// Find the character property value, or None.
+    /// The property value for the character, or None.
     fn of(ch: char) -> Option<Self>;
 }
 
@@ -47,7 +47,7 @@ pub trait PartialCharProperty: Copy {
 // TODO: Drop extra super-traits after the bugs are fixed.
 //pub trait CompleteCharProperty: PartialCharProperty + Default {
 pub trait CompleteCharProperty : PartialCharProperty + Copy + Default {
-    /// Find the character property value.
+    /// The property value for the character.
     fn of(ch: char) -> Self;
 }
 

--- a/unic/char/property/src/range_types.rs
+++ b/unic/char/property/src/range_types.rs
@@ -28,8 +28,15 @@ pub trait EnumeratedCharProperty: Sized + CharProperty {
     /// Exhaustive list of all property values.
     fn all_values() -> &'static [Self];
 
-    /// Get *abbreviated name* of the property value
+    /// The *abbreviated name* of the property value.
     fn abbr_name(&self) -> &'static str;
+
+    /// The *long name* of the property value.
+    fn long_name(&self) -> &'static str;
+
+    /// The *human-readable name* of the property value.
+    fn human_name(&self) -> &'static str;
+
 }
 
 
@@ -45,6 +52,6 @@ impl NumericCharPropertyValue for u8 {}
 ///
 /// Examples: *Numeric_Value*, *Canonical_Combining_Class*
 pub trait NumericCharProperty<Value: NumericCharPropertyValue>: CharProperty {
-    /// Get numeric value for character property value
+    /// The numeric value for the property value.
     fn number(&self) -> Value;
 }

--- a/unic/char/property/src/range_types.rs
+++ b/unic/char/property/src/range_types.rs
@@ -36,7 +36,6 @@ pub trait EnumeratedCharProperty: Sized + CharProperty {
 
     /// The *human-readable name* of the property value.
     fn human_name(&self) -> &'static str;
-
 }
 
 

--- a/unic/char/property/tests/macro_tests.rs
+++ b/unic/char/property/tests/macro_tests.rs
@@ -43,6 +43,7 @@ char_property! {
 }
 
 
+// TODO: Impl by char_property!()
 impl CharProperty for MyProp {
     fn prop_abbr_name() -> &'static str {
         "myprop"
@@ -56,6 +57,7 @@ impl CharProperty for MyProp {
         "MyProp"
     }
 }
+
 
 impl PartialCharProperty for MyProp {
     fn of(_: char) -> Option<Self> {

--- a/unic/ucd/bidi/src/bidi_class.rs
+++ b/unic/ucd/bidi/src/bidi_class.rs
@@ -82,6 +82,14 @@ impl EnumeratedCharProperty for BidiClass {
     fn abbr_name(&self) -> &'static str {
         self.abbr_name()
     }
+
+    fn long_name(&self) -> &'static str {
+        self.long_name()
+    }
+
+    fn human_name(&self) -> &'static str {
+        self.human_name()
+    }
 }
 
 
@@ -150,102 +158,126 @@ impl BidiClass {
 
     /// Exhaustive list of all `BidiClass` property values.
     pub fn all_values() -> &'static [BidiClass] {
-        use BidiClass::*;
         const ALL_VALUES: &[BidiClass] = &[
-            ArabicLetter,
-            ArabicNumber,
-            ParagraphSeparator,
-            BoundaryNeutral,
-            CommonSeparator,
-            EuropeanNumber,
-            EuropeanSeparator,
-            EuropeanTerminator,
-            FirstStrongIsolate,
-            LeftToRight,
-            LeftToRightEmbedding,
-            LeftToRightIsolate,
-            LeftToRightOverride,
-            NonspacingMark,
-            OtherNeutral,
-            PopDirectionalFormat,
-            PopDirectionalIsolate,
-            RightToLeft,
-            RightToLeftEmbedding,
-            RightToLeftIsolate,
-            RightToLeftOverride,
-            SegmentSeparator,
-            WhiteSpace,
+            BidiClass::ArabicLetter,
+            BidiClass::ArabicNumber,
+            BidiClass::ParagraphSeparator,
+            BidiClass::BoundaryNeutral,
+            BidiClass::CommonSeparator,
+            BidiClass::EuropeanNumber,
+            BidiClass::EuropeanSeparator,
+            BidiClass::EuropeanTerminator,
+            BidiClass::FirstStrongIsolate,
+            BidiClass::LeftToRight,
+            BidiClass::LeftToRightEmbedding,
+            BidiClass::LeftToRightIsolate,
+            BidiClass::LeftToRightOverride,
+            BidiClass::NonspacingMark,
+            BidiClass::OtherNeutral,
+            BidiClass::PopDirectionalFormat,
+            BidiClass::PopDirectionalIsolate,
+            BidiClass::RightToLeft,
+            BidiClass::RightToLeftEmbedding,
+            BidiClass::RightToLeftIsolate,
+            BidiClass::RightToLeftOverride,
+            BidiClass::SegmentSeparator,
+            BidiClass::WhiteSpace,
         ];
         ALL_VALUES
     }
-    /// Abbreviated name of the *Bidi_Class* property value.
-    ///
-    /// <http://www.unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt#Bidi_Class>
+
+    /// The *abbreviated name* of the property value.
     pub fn abbr_name(&self) -> &'static str {
-        use BidiClass::*;
         match *self {
-            ArabicLetter => "AL",
-            ArabicNumber => "AN",
-            ParagraphSeparator => "B",
-            BoundaryNeutral => "BN",
-            CommonSeparator => "CS",
-            EuropeanNumber => "EN",
-            EuropeanSeparator => "ES",
-            EuropeanTerminator => "ET",
-            FirstStrongIsolate => "FSI",
-            LeftToRight => "L",
-            LeftToRightEmbedding => "LRE",
-            LeftToRightIsolate => "LRI",
-            LeftToRightOverride => "LRO",
-            NonspacingMark => "NSM",
-            OtherNeutral => "ON",
-            PopDirectionalFormat => "PDF",
-            PopDirectionalIsolate => "PDI",
-            RightToLeft => "R",
-            RightToLeftEmbedding => "RLE",
-            RightToLeftIsolate => "RLI",
-            RightToLeftOverride => "RLO",
-            SegmentSeparator => "S",
-            WhiteSpace => "WS",
+            BidiClass::ArabicLetter => "AL",
+            BidiClass::ArabicNumber => "AN",
+            BidiClass::ParagraphSeparator => "B",
+            BidiClass::BoundaryNeutral => "BN",
+            BidiClass::CommonSeparator => "CS",
+            BidiClass::EuropeanNumber => "EN",
+            BidiClass::EuropeanSeparator => "ES",
+            BidiClass::EuropeanTerminator => "ET",
+            BidiClass::FirstStrongIsolate => "FSI",
+            BidiClass::LeftToRight => "L",
+            BidiClass::LeftToRightEmbedding => "LRE",
+            BidiClass::LeftToRightIsolate => "LRI",
+            BidiClass::LeftToRightOverride => "LRO",
+            BidiClass::NonspacingMark => "NSM",
+            BidiClass::OtherNeutral => "ON",
+            BidiClass::PopDirectionalFormat => "PDF",
+            BidiClass::PopDirectionalIsolate => "PDI",
+            BidiClass::RightToLeft => "R",
+            BidiClass::RightToLeftEmbedding => "RLE",
+            BidiClass::RightToLeftIsolate => "RLI",
+            BidiClass::RightToLeftOverride => "RLO",
+            BidiClass::SegmentSeparator => "S",
+            BidiClass::WhiteSpace => "WS",
         }
     }
 
-    /// Human-readable description of the *Bidi_Class* property value.
-    ///
-    /// <http://www.unicode.org/reports/tr9/#Table_Bidirectional_Character_Types>
+    /// The *long name* of the property value.
+    pub fn long_name(&self) -> &'static str {
+        match *self {
+            BidiClass::ArabicLetter => "Arabic_Letter",
+            BidiClass::ArabicNumber => "Arabic_Number",
+            BidiClass::ParagraphSeparator => "Paragraph_Separator",
+            BidiClass::BoundaryNeutral => "Boundary_Neutral",
+            BidiClass::CommonSeparator => "Common_Separator",
+            BidiClass::EuropeanNumber => "European_Number",
+            BidiClass::EuropeanSeparator => "European_Separator",
+            BidiClass::EuropeanTerminator => "European_Terminator",
+            BidiClass::FirstStrongIsolate => "First_Strong_Isolate",
+            BidiClass::LeftToRight => "Left_To_Right",
+            BidiClass::LeftToRightEmbedding => "Left_To_Right_Embedding",
+            BidiClass::LeftToRightIsolate => "Left_To_Right_Isolate",
+            BidiClass::LeftToRightOverride => "Left_To_Right_Override",
+            BidiClass::NonspacingMark => "Nonspacing_Mark",
+            BidiClass::OtherNeutral => "Other_Neutral",
+            BidiClass::PopDirectionalFormat => "Pop_Directional_Format",
+            BidiClass::PopDirectionalIsolate => "Pop_Directional_Isolate",
+            BidiClass::RightToLeft => "Right_To_Left",
+            BidiClass::RightToLeftEmbedding => "Right_To_Left_Embedding",
+            BidiClass::RightToLeftIsolate => "Right_To_Left_Isolate",
+            BidiClass::RightToLeftOverride => "Right_To_Left_Override",
+            BidiClass::SegmentSeparator => "Segment_Separator",
+            BidiClass::WhiteSpace => "White_Space",
+        }
+    }
+
+    /// The *human-readable name* of the property value.
     #[inline]
-    pub fn display(&self) -> &str {
+    pub fn human_name(&self) -> &'static str {
         match *self {
             // Strong
-            L => "Left-to-Right",
-            R => "Right-to-Left",
-            AL => "Right-to-Left Arabic",
+            BidiClass::LeftToRight => "Left-to-Right",
+            BidiClass::RightToLeft => "Right-to-Left",
+            BidiClass::ArabicLetter => "Right-to-Left Arabic",
 
             // Weak
-            EN => "European Number",
-            ES => "European Number Separator",
-            ET => "European Number Terminator",
-            AN => "Arabic Number",
-            CS => "Common Number Separator",
-            NSM => "Nonspacing Mark",
-            BN => "Boundary Neutral",
+            BidiClass::EuropeanNumber => "European Number",
+            BidiClass::EuropeanSeparator => "European Number Separator",
+            BidiClass::EuropeanTerminator => "European Number Terminator",
+            BidiClass::ArabicNumber => "Arabic Number",
+            BidiClass::CommonSeparator => "Common Number Separator",
+            BidiClass::NonspacingMark => "Nonspacing Mark",
+            BidiClass::BoundaryNeutral => "Boundary Neutral",
 
             // Neutral
-            B => "Paragraph Separator",
-            S => "Segment Separator",
-            WS => "Whitespace",
-            ON => "Other Neutrals",
+            BidiClass::ParagraphSeparator => "Paragraph Separator",
+            BidiClass::SegmentSeparator => "Segment Separator",
+            BidiClass::WhiteSpace => "Whitespace",
+            BidiClass::OtherNeutral => "Other Neutrals",
 
             // Explicit Formatting
-            LRE => "Left-to-Right Embedding",
-            LRO => "Left-to-Right Override",
-            RLE => "Right-to-Left Embedding",
-            RLO => "Right-to-Left Override",
-            PDF => "Pop Directional Format",
-            LRI => "Left-to-Right Isolate",
-            RLI => "Right-to-Left Isolate",
-            FSI => "First Strong Isolate",
-            PDI => "Pop Directional Isolate",
+            BidiClass::LeftToRightEmbedding => "Left-to-Right Embedding",
+            BidiClass::LeftToRightOverride => "Left-to-Right Override",
+            BidiClass::RightToLeftEmbedding => "Right-to-Left Embedding",
+            BidiClass::RightToLeftOverride => "Right-to-Left Override",
+            BidiClass::PopDirectionalFormat => "Pop Directional Format",
+            BidiClass::LeftToRightIsolate => "Left-to-Right Isolate",
+            BidiClass::RightToLeftIsolate => "Right-to-Left Isolate",
+            BidiClass::FirstStrongIsolate => "First Strong Isolate",
+            BidiClass::PopDirectionalIsolate => "Pop Directional Isolate",
         }
     }
 
@@ -291,7 +323,7 @@ impl Default for BidiClass {
 
 impl fmt::Display for BidiClass {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.display())
+        write!(f, "{}", self.human_name())
     }
 }
 
@@ -383,15 +415,28 @@ mod tests {
     }
 
     #[test]
+    fn test_abbr_name() {
+        assert_eq!(AL.abbr_name(), "AL");
+        assert_eq!(FSI.abbr_name(), "FSI");
+    }
+
+    #[test]
+    fn test_long_name() {
+        assert_eq!(AL.long_name(), "Arabic_Letter");
+        assert_eq!(FSI.long_name(), "First_Strong_Isolate");
+    }
+
+    #[test]
+    fn test_human_name() {
+        assert_eq!(AL.human_name(), "Right-to-Left Arabic");
+        assert_eq!(FSI.human_name(), "First Strong Isolate");
+    }
+
+    #[test]
     fn test_display() {
         assert_eq!(format!("{}", L), "Left-to-Right");
         assert_eq!(format!("{}", R), "Right-to-Left");
         assert_eq!(format!("{}", AL), "Right-to-Left Arabic");
         assert_eq!(format!("{}", FSI), "First Strong Isolate");
-    }
-
-    #[test]
-    fn test_abbr_name() {
-        assert_eq!(AL.abbr_name(), "AL");
     }
 }

--- a/unic/ucd/category/src/category.rs
+++ b/unic/ucd/category/src/category.rs
@@ -116,6 +116,14 @@ impl EnumeratedCharProperty for GeneralCategory {
     fn abbr_name(&self) -> &'static str {
         self.abbr_name()
     }
+
+    fn long_name(&self) -> &'static str {
+        self.long_name()
+    }
+
+    fn human_name(&self) -> &'static str {
+        self.human_name()
+    }
 }
 
 
@@ -164,86 +172,148 @@ impl GeneralCategory {
 
     /// Exhaustive list of all `GeneralCategory` property values.
     pub fn all_values() -> &'static [GeneralCategory] {
-        use GeneralCategory::*;
         const ALL_VALUES: &[GeneralCategory] = &[
-            UppercaseLetter,
-            LowercaseLetter,
-            TitlecaseLetter,
-            ModifierLetter,
-            OtherLetter,
-            NonspacingMark,
-            SpacingMark,
-            EnclosingMark,
-            DecimalNumber,
-            LetterNumber,
-            OtherNumber,
-            ConnectorPunctuation,
-            DashPunctuation,
-            OpenPunctuation,
-            ClosePunctuation,
-            InitialPunctuation,
-            FinalPunctuation,
-            OtherPunctuation,
-            MathSymbol,
-            CurrencySymbol,
-            ModifierSymbol,
-            OtherSymbol,
-            SpaceSeparator,
-            LineSeparator,
-            ParagraphSeparator,
-            Control,
-            Format,
-            Surrogate,
-            PrivateUse,
-            Unassigned,
+            GeneralCategory::UppercaseLetter,
+            GeneralCategory::LowercaseLetter,
+            GeneralCategory::TitlecaseLetter,
+            GeneralCategory::ModifierLetter,
+            GeneralCategory::OtherLetter,
+            GeneralCategory::NonspacingMark,
+            GeneralCategory::SpacingMark,
+            GeneralCategory::EnclosingMark,
+            GeneralCategory::DecimalNumber,
+            GeneralCategory::LetterNumber,
+            GeneralCategory::OtherNumber,
+            GeneralCategory::ConnectorPunctuation,
+            GeneralCategory::DashPunctuation,
+            GeneralCategory::OpenPunctuation,
+            GeneralCategory::ClosePunctuation,
+            GeneralCategory::InitialPunctuation,
+            GeneralCategory::FinalPunctuation,
+            GeneralCategory::OtherPunctuation,
+            GeneralCategory::MathSymbol,
+            GeneralCategory::CurrencySymbol,
+            GeneralCategory::ModifierSymbol,
+            GeneralCategory::OtherSymbol,
+            GeneralCategory::SpaceSeparator,
+            GeneralCategory::LineSeparator,
+            GeneralCategory::ParagraphSeparator,
+            GeneralCategory::Control,
+            GeneralCategory::Format,
+            GeneralCategory::Surrogate,
+            GeneralCategory::PrivateUse,
+            GeneralCategory::Unassigned,
         ];
         ALL_VALUES
     }
 
-    /// Abbreviated name of the *General_Category* property value.
-    ///
-    /// <http://www.unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt#General_Category>
+    /// The *abbreviated name* of the property value.
     pub fn abbr_name(&self) -> &'static str {
-        use GeneralCategory::*;
         match *self {
-            UppercaseLetter => "Lu",
-            LowercaseLetter => "Ll",
-            TitlecaseLetter => "Lt",
-            ModifierLetter => "Lm",
-            OtherLetter => "Lo",
-            NonspacingMark => "Mn",
-            SpacingMark => "Mc",
-            EnclosingMark => "Me",
-            DecimalNumber => "Nd",
-            LetterNumber => "Nl",
-            OtherNumber => "No",
-            ConnectorPunctuation => "Pc",
-            DashPunctuation => "Pd",
-            OpenPunctuation => "Ps",
-            ClosePunctuation => "Pe",
-            InitialPunctuation => "Pi",
-            FinalPunctuation => "Pf",
-            OtherPunctuation => "Po",
-            MathSymbol => "Sm",
-            CurrencySymbol => "Sc",
-            ModifierSymbol => "Sk",
-            OtherSymbol => "So",
-            SpaceSeparator => "Zs",
-            LineSeparator => "Zl",
-            ParagraphSeparator => "Zp",
-            Control => "Cc",
-            Format => "Cf",
-            Surrogate => "Cs",
-            PrivateUse => "Co",
-            Unassigned => "Cn",
+            GeneralCategory::UppercaseLetter => "Lu",
+            GeneralCategory::LowercaseLetter => "Ll",
+            GeneralCategory::TitlecaseLetter => "Lt",
+            GeneralCategory::ModifierLetter => "Lm",
+            GeneralCategory::OtherLetter => "Lo",
+            GeneralCategory::NonspacingMark => "Mn",
+            GeneralCategory::SpacingMark => "Mc",
+            GeneralCategory::EnclosingMark => "Me",
+            GeneralCategory::DecimalNumber => "Nd",
+            GeneralCategory::LetterNumber => "Nl",
+            GeneralCategory::OtherNumber => "No",
+            GeneralCategory::ConnectorPunctuation => "Pc",
+            GeneralCategory::DashPunctuation => "Pd",
+            GeneralCategory::OpenPunctuation => "Ps",
+            GeneralCategory::ClosePunctuation => "Pe",
+            GeneralCategory::InitialPunctuation => "Pi",
+            GeneralCategory::FinalPunctuation => "Pf",
+            GeneralCategory::OtherPunctuation => "Po",
+            GeneralCategory::MathSymbol => "Sm",
+            GeneralCategory::CurrencySymbol => "Sc",
+            GeneralCategory::ModifierSymbol => "Sk",
+            GeneralCategory::OtherSymbol => "So",
+            GeneralCategory::SpaceSeparator => "Zs",
+            GeneralCategory::LineSeparator => "Zl",
+            GeneralCategory::ParagraphSeparator => "Zp",
+            GeneralCategory::Control => "Cc",
+            GeneralCategory::Format => "Cf",
+            GeneralCategory::Surrogate => "Cs",
+            GeneralCategory::PrivateUse => "Co",
+            GeneralCategory::Unassigned => "Cn",
         }
     }
 
-    /// Human-readable description of the property value.
-    // TODO: Needs to be improved by returning long-name with underscores replaced by space.
+    /// The *long name* of the property value.
+    pub fn long_name(&self) -> &'static str {
+        match *self {
+            GeneralCategory::UppercaseLetter => "Uppercase_Letter",
+            GeneralCategory::LowercaseLetter => "Lowercase_Letter",
+            GeneralCategory::TitlecaseLetter => "Titlecase_Letter",
+            GeneralCategory::ModifierLetter => "Modifier_Letter",
+            GeneralCategory::OtherLetter => "Other_Letter",
+            GeneralCategory::NonspacingMark => "Nonspacing_Mark",
+            GeneralCategory::SpacingMark => "Spacing_Mark",
+            GeneralCategory::EnclosingMark => "Enclosing_Mark",
+            GeneralCategory::DecimalNumber => "Decimal_Number",
+            GeneralCategory::LetterNumber => "Letter_Number",
+            GeneralCategory::OtherNumber => "Other_Number",
+            GeneralCategory::ConnectorPunctuation => "Connector_Punctuation",
+            GeneralCategory::DashPunctuation => "Dash_Punctuation",
+            GeneralCategory::OpenPunctuation => "Open_Punctuation",
+            GeneralCategory::ClosePunctuation => "Close_Punctuation",
+            GeneralCategory::InitialPunctuation => "Initial_Punctuation",
+            GeneralCategory::FinalPunctuation => "Final_Punctuation",
+            GeneralCategory::OtherPunctuation => "Other_Punctuation",
+            GeneralCategory::MathSymbol => "Math_Symbol",
+            GeneralCategory::CurrencySymbol => "Currency_Symbol",
+            GeneralCategory::ModifierSymbol => "Modifier_Symbol",
+            GeneralCategory::OtherSymbol => "Other_Symbol",
+            GeneralCategory::SpaceSeparator => "Space_Separator",
+            GeneralCategory::LineSeparator => "Line_Separator",
+            GeneralCategory::ParagraphSeparator => "Paragraph_Separator",
+            GeneralCategory::Control => "Control",
+            GeneralCategory::Format => "Format",
+            GeneralCategory::Surrogate => "Surrogate",
+            GeneralCategory::PrivateUse => "Private_Use",
+            GeneralCategory::Unassigned => "Unassigned",
+        }
+    }
+
+    /// The *human-readable name* of the property value.
     #[inline]
-    pub fn display(&self) -> String {
-        format!("{:?}", self).to_owned()
+    pub fn human_name(&self) -> &'static str {
+        match *self {
+            GeneralCategory::UppercaseLetter => "Uppercase Letter",
+            GeneralCategory::LowercaseLetter => "Lowercase Letter",
+            GeneralCategory::TitlecaseLetter => "Titlecase Letter",
+            GeneralCategory::ModifierLetter => "Modifier Letter",
+            GeneralCategory::OtherLetter => "Other Letter",
+            GeneralCategory::NonspacingMark => "Nonspacing Mark",
+            GeneralCategory::SpacingMark => "Spacing Mark",
+            GeneralCategory::EnclosingMark => "Enclosing Mark",
+            GeneralCategory::DecimalNumber => "Decimal Number",
+            GeneralCategory::LetterNumber => "Letter Number",
+            GeneralCategory::OtherNumber => "Other Number",
+            GeneralCategory::ConnectorPunctuation => "Connector Punctuation",
+            GeneralCategory::DashPunctuation => "Dash Punctuation",
+            GeneralCategory::OpenPunctuation => "Open Punctuation",
+            GeneralCategory::ClosePunctuation => "Close Punctuation",
+            GeneralCategory::InitialPunctuation => "Initial Punctuation",
+            GeneralCategory::FinalPunctuation => "Final Punctuation",
+            GeneralCategory::OtherPunctuation => "Other Punctuation",
+            GeneralCategory::MathSymbol => "Math Symbol",
+            GeneralCategory::CurrencySymbol => "Currency Symbol",
+            GeneralCategory::ModifierSymbol => "Modifier Symbol",
+            GeneralCategory::OtherSymbol => "Other Symbol",
+            GeneralCategory::SpaceSeparator => "Space Separator",
+            GeneralCategory::LineSeparator => "Line Separator",
+            GeneralCategory::ParagraphSeparator => "Paragraph Separator",
+            GeneralCategory::Control => "Control",
+            GeneralCategory::Format => "Format",
+            GeneralCategory::Surrogate => "Surrogate",
+            GeneralCategory::PrivateUse => "Private Use",
+            GeneralCategory::Unassigned => "Unassigned",
+        }
     }
 }
 
@@ -300,7 +370,7 @@ impl Default for GeneralCategory {
 
 impl fmt::Display for GeneralCategory {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.display())
+        write!(f, "{}", self.human_name())
     }
 }
 
@@ -405,15 +475,26 @@ mod tests {
     }
 
     #[test]
-    fn test_display() {
-        //assert_eq!(format!("{}", GC::UppercaseLetter), "Uppercase Letter");
-        assert_eq!(format!("{}", GC::UppercaseLetter), "UppercaseLetter");
-        assert_eq!(format!("{}", GC::Unassigned), "Unassigned");
+    fn test_abbr_name() {
+        assert_eq!(GC::UppercaseLetter.abbr_name(), "Lu");
+        assert_eq!(GC::Unassigned.abbr_name(), "Cn");
     }
 
     #[test]
-    fn test_abbr_name() {
-        use super::abbr_names::*;
-        assert_eq!(Lu.abbr_name(), "Lu");
+    fn test_long_name() {
+        assert_eq!(GC::UppercaseLetter.long_name(), "Uppercase_Letter");
+        assert_eq!(GC::Unassigned.long_name(), "Unassigned");
+    }
+
+    #[test]
+    fn test_human_name() {
+        assert_eq!(GC::UppercaseLetter.human_name(), "Uppercase Letter");
+        assert_eq!(GC::Unassigned.human_name(), "Unassigned");
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(format!("{}", GC::UppercaseLetter), "Uppercase Letter");
+        assert_eq!(format!("{}", GC::Unassigned), "Unassigned");
     }
 }

--- a/unic/ucd/normal/src/decomposition_type.rs
+++ b/unic/ucd/normal/src/decomposition_type.rs
@@ -79,6 +79,14 @@ impl EnumeratedCharProperty for DecompositionType {
     fn abbr_name(&self) -> &'static str {
         self.abbr_name()
     }
+
+    fn long_name(&self) -> &'static str {
+        self.long_name()
+    }
+
+    fn human_name(&self) -> &'static str {
+        self.human_name()
+    }
 }
 
 
@@ -143,45 +151,83 @@ impl DecompositionType {
         ALL_VALUES
     }
 
-    /// Abbreviated name of the *Decomposition_Type* property value.
-    ///
-    /// <http://www.unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt#Decomposition_Type>
+    /// The *abbreviated name* of the property value.
     pub fn abbr_name(&self) -> &'static str {
-        use DecompositionType::*;
         match *self {
-            Canonical => "Can",
-            Compat => "Com",
-            Circle => "Enc",
-            Final => "Fin",
-            Font => "Font",
-            Fraction => "Fra",
-            Initial => "Init",
-            Isolated => "Iso",
-            Medial => "Med",
-            Narrow => "Nar",
-            Nobreak => "Nb",
-            None => "None",
-            Small => "Sml",
-            Square => "Sqr",
-            Sub => "Sub",
-            Super => "Sup",
-            Vertical => "Vert",
-            Wide => "Wide",
+            DecompositionType::Canonical => "Can",
+            DecompositionType::Compat => "Com",
+            DecompositionType::Circle => "Enc",
+            DecompositionType::Final => "Fin",
+            DecompositionType::Font => "Font",
+            DecompositionType::Fraction => "Fra",
+            DecompositionType::Initial => "Init",
+            DecompositionType::Isolated => "Iso",
+            DecompositionType::Medial => "Med",
+            DecompositionType::Narrow => "Nar",
+            DecompositionType::Nobreak => "Nb",
+            DecompositionType::None => "None",
+            DecompositionType::Small => "Sml",
+            DecompositionType::Square => "Sqr",
+            DecompositionType::Sub => "Sub",
+            DecompositionType::Super => "Sup",
+            DecompositionType::Vertical => "Vert",
+            DecompositionType::Wide => "Wide",
         }
     }
 
-    /// Human-readable description of the property value.
-    // TODO: Needs to be improved by returning long-name with underscores replaced by space.
-    #[inline]
-    pub fn display(&self) -> String {
-        format!("{:?}", self).to_owned()
+    /// The *long name* of the property value.
+    pub fn long_name(&self) -> &'static str {
+        match *self {
+            DecompositionType::Canonical => "Canonical",
+            DecompositionType::Compat => "Compat",
+            DecompositionType::Circle => "Circle",
+            DecompositionType::Final => "Final",
+            DecompositionType::Font => "Font",
+            DecompositionType::Fraction => "Fraction",
+            DecompositionType::Initial => "Initial",
+            DecompositionType::Isolated => "Isolated",
+            DecompositionType::Medial => "Medial",
+            DecompositionType::Narrow => "Narrow",
+            DecompositionType::Nobreak => "Nobreak",
+            DecompositionType::None => "None",
+            DecompositionType::Small => "Small",
+            DecompositionType::Square => "Square",
+            DecompositionType::Sub => "Sub",
+            DecompositionType::Super => "Super",
+            DecompositionType::Vertical => "Vertical",
+            DecompositionType::Wide => "Wide",
+        }
+    }
+
+    /// The *human-readable name* of the property value.
+    pub fn human_name(&self) -> &'static str {
+        match *self {
+            DecompositionType::Canonical => "Canonical",
+            DecompositionType::Compat => "Compat",
+            DecompositionType::Circle => "Circle",
+            DecompositionType::Final => "Final",
+            DecompositionType::Font => "Font",
+            DecompositionType::Fraction => "Fraction",
+            DecompositionType::Initial => "Initial",
+            DecompositionType::Isolated => "Isolated",
+            DecompositionType::Medial => "Medial",
+            DecompositionType::Narrow => "Narrow",
+            DecompositionType::Nobreak => "No-Break",
+            DecompositionType::None => "None",
+            DecompositionType::Small => "Small",
+            DecompositionType::Square => "Square",
+            DecompositionType::Sub => "Sub",
+            DecompositionType::Super => "Super",
+            DecompositionType::Vertical => "Vertical",
+            DecompositionType::Wide => "Wide",
+        }
     }
 }
 
 
 impl fmt::Display for DecompositionType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.display())
+        write!(f, "{}", self.human_name())
     }
 }
 
@@ -316,13 +362,25 @@ mod tests {
     }
 
     #[test]
-    fn test_display() {
-        assert_eq!(format!("{}", DT::of('\u{a0}').unwrap()), "Nobreak");
+    fn test_abbr_name() {
+        assert_eq!(DT::Canonical.abbr_name(), "Can");
+        assert_eq!(DT::Nobreak.abbr_name(), "Nb");
     }
 
     #[test]
-    fn test_abbr_name() {
-        use super::abbr_names::*;
-        assert_eq!(Can.abbr_name(), "Can");
+    fn test_long_name() {
+        assert_eq!(DT::Canonical.long_name(), "Canonical");
+        assert_eq!(DT::Nobreak.long_name(), "Nobreak");
+    }
+
+    #[test]
+    fn test_human_name() {
+        assert_eq!(DT::Canonical.human_name(), "Canonical");
+        assert_eq!(DT::Nobreak.human_name(), "No-Break");
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(format!("{}", DT::of('\u{a0}').unwrap()), "No-Break");
     }
 }

--- a/unic/ucd/normal/tests/excluded_composition_tests.rs
+++ b/unic/ucd/normal/tests/excluded_composition_tests.rs
@@ -82,17 +82,13 @@ fn test_composition_exclusions() {
 
     for char in battery.iter() {
         let decomposition = canonical_decomposition(*char).unwrap();
-        assert!(
-            !canonical_composition(decomposition[0])
-                .unwrap_or(&[])
-                .iter()
-                .any(|&(follow, _)| follow == decomposition[1])
-        );
-        assert!(
-            !canonical_composition(decomposition[0])
-                .unwrap_or(&[])
-                .iter()
-                .any(|&(_, ref result)| battery.contains(result))
-        );
+        assert!(!canonical_composition(decomposition[0])
+            .unwrap_or(&[])
+            .iter()
+            .any(|&(follow, _)| follow == decomposition[1]));
+        assert!(!canonical_composition(decomposition[0])
+            .unwrap_or(&[])
+            .iter()
+            .any(|&(_, ref result)| battery.contains(result)));
     }
 }


### PR DESCRIPTION
Add `long_name(&self)`/`human_name(&self)` to the
`EnumeratedCharProperty` contract and add values to the implementing
types.

Also needs to be implemented by `char_property!` macro.

These name methods *may* not belong to *Enumerated* contract, but this
is the only contract we have right now that provides them, so let's
start with having them here.

Bascially, looks like we have to major categories of property range
types: those with pre-defined set of possible values (*Enumerated*, and
possibly other ones), and those with numeric/complex values, which don't
have *named* variants for all of them, which would result in
name-generation to be runtime and not compile time.

For the second group, we can add another parent contract to implement
these methods as `fn *_name(&self) -> String`, which are clearly more
expensive and may not be used when `&'static str` is accepted.

This way, we keep the API similar enough to remember, but also not
enforcing runtime overhead.