### PR TITLE
[ucd] Drop `use ...::*` lines outside of data or tests

### DIFF
--- a/unic/ucd/bidi/src/bidi_class.rs
+++ b/unic/ucd/bidi/src/bidi_class.rs
@@ -216,19 +216,90 @@ impl CompleteCharProperty for BidiClass {
 
 
 impl Default for BidiClass {
+    #[inline]
     fn default() -> Self {
         BidiClass::LeftToRight
     }
 }
 
 
-use self::abbr_names::*;
+mod data {
+    use super::abbr_names::*;
+    pub const BIDI_CLASS_TABLE: &'static [(char, char, super::BidiClass)] =
+        include!("tables/bidi_class_values.rsv");
+}
 
-const BIDI_CLASS_TABLE: &'static [(char, char, BidiClass)] =
-    include!("tables/bidi_class_values.rsv");
 
-/// Represents the **Category** of the Unicode character property `Bidi_Class`,
-/// as demonstrated under "Table 4. Bidirectional Character Types".
+impl BidiClass {
+    /// Find the character *Bidi_Class* property value.
+    pub fn of(ch: char) -> BidiClass {
+        // UCD/extracted/DerivedBidiClass.txt: "All code points not explicitly listed
+        // for Bidi_Class have the value Left_To_Right (L)."
+        *data::BIDI_CLASS_TABLE.find_or(ch, &Default::default())
+    }
+
+    /// If the `BidiClass` has strong or explicit Left-to-Right direction.
+    #[inline]
+    pub fn category(&self) -> BidiClassCategory {
+        match *self {
+            BidiClass::LeftToRight | BidiClass::RightToLeft | BidiClass::ArabicLetter => {
+                BidiClassCategory::Strong
+            }
+
+            BidiClass::EuropeanNumber |
+            BidiClass::EuropeanSeparator |
+            BidiClass::EuropeanTerminator |
+            BidiClass::ArabicNumber |
+            BidiClass::CommonSeparator |
+            BidiClass::NonspacingMark |
+            BidiClass::BoundaryNeutral => BidiClassCategory::Weak,
+
+            BidiClass::ParagraphSeparator |
+            BidiClass::SegmentSeparator |
+            BidiClass::WhiteSpace |
+            BidiClass::OtherNeutral => BidiClassCategory::Neutral,
+
+            BidiClass::LeftToRightEmbedding |
+            BidiClass::LeftToRightOverride |
+            BidiClass::RightToLeftEmbedding |
+            BidiClass::RightToLeftOverride |
+            BidiClass::PopDirectionalFormat |
+            BidiClass::LeftToRightIsolate |
+            BidiClass::RightToLeftIsolate |
+            BidiClass::FirstStrongIsolate |
+            BidiClass::PopDirectionalIsolate => BidiClassCategory::ExplicitFormatting,
+        }
+    }
+
+    /// If the `BidiClass` has strong or explicit Left-to-Right direction.
+    #[inline]
+    pub fn is_ltr(&self) -> bool {
+        match *self {
+            BidiClass::LeftToRight |
+            BidiClass::LeftToRightEmbedding |
+            BidiClass::LeftToRightOverride |
+            BidiClass::LeftToRightIsolate => true,
+            _ => false,
+        }
+    }
+
+    /// If the `BidiClass` has strong or explicit Right-To-Left direction.
+    #[inline]
+    pub fn is_rtl(&self) -> bool {
+        match *self {
+            BidiClass::RightToLeft |
+            BidiClass::ArabicLetter |
+            BidiClass::RightToLeftEmbedding |
+            BidiClass::RightToLeftOverride |
+            BidiClass::RightToLeftIsolate => true,
+            _ => false,
+        }
+    }
+}
+
+
+/// Represents **Category** of Unicode character `Bidi_Class` property, as demostrated under "Table
+/// 4. Bidirectional Character Types".
 ///
 /// * <http://www.unicode.org/reports/tr9/#Table_Bidirectional_Character_Types>
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -244,46 +315,6 @@ pub enum BidiClassCategory {
 
     /// Everything else.
     Neutral,
-}
-
-impl BidiClass {
-    /// Find the character *Bidi_Class* property value.
-    pub fn of(ch: char) -> BidiClass {
-        // UCD/extracted/DerivedBidiClass.txt: "All code points not explicitly listed
-        // for Bidi_Class have the value Left_To_Right (L)."
-        *BIDI_CLASS_TABLE.find_or(ch, &Default::default())
-    }
-
-    /// If the `BidiClass` has strong or explicit Left-to-Right direction.
-    #[inline]
-    pub fn category(&self) -> BidiClassCategory {
-        match *self {
-            L | R | AL => BidiClassCategory::Strong,
-            EN | ES | ET | AN | CS | NSM | BN => BidiClassCategory::Weak,
-            B | S | WS | ON => BidiClassCategory::Neutral,
-            LRE | LRO | RLE | RLO | PDF | LRI | RLI | FSI | PDI => {
-                BidiClassCategory::ExplicitFormatting
-            }
-        }
-    }
-
-    /// If the `BidiClass` has strong or explicit Left-to-Right direction.
-    #[inline]
-    pub fn is_ltr(&self) -> bool {
-        match *self {
-            L | LRE | LRO | LRI => true,
-            _ => false,
-        }
-    }
-
-    /// If the `BidiClass` has strong or explicit Right-To-Left direction.
-    #[inline]
-    pub fn is_rtl(&self) -> bool {
-        match *self {
-            AL | R | RLE | RLO | RLI => true,
-            _ => false,
-        }
-    }
 }
 
 

--- a/unic/ucd/category/src/category.rs
+++ b/unic/ucd/category/src/category.rs
@@ -254,16 +254,18 @@ impl Default for GeneralCategory {
 }
 
 
-use self::abbr_names::*;
+mod data {
+    use super::abbr_names::*;
+    pub const GENERAL_CATEGORY_TABLE: &'static [(char, char, super::GeneralCategory)] =
+        include!("tables/general_category.rsv");
+}
 
-const GENERAL_CATEGORY_TABLE: &'static [(char, char, GeneralCategory)] =
-    include!("tables/general_category.rsv");
 
 
 impl GeneralCategory {
     /// Find the `GeneralCategory` of a single char.
     pub fn of(ch: char) -> GeneralCategory {
-        *GENERAL_CATEGORY_TABLE.find_or(ch, &GeneralCategory::Unassigned)
+        *data::GENERAL_CATEGORY_TABLE.find_or(ch, &GeneralCategory::Unassigned)
     }
 }
 
@@ -271,41 +273,49 @@ impl GeneralCategory {
 impl GeneralCategory {
     /// `Lu` | `Ll` | `Lt`  (Short form: `LC`)
     pub fn is_cased_letter(&self) -> bool {
+        use self::abbr_names::*;
         matches!(*self, Lu | Ll | Lt)
     }
 
     /// `Lu` | `Ll` | `Lt` | `Lm` | `Lo`  (Short form: `L`)
     pub fn is_letter(&self) -> bool {
+        use self::abbr_names::*;
         matches!(*self, Lu | Ll | Lt | Lm | Lo)
     }
 
     /// `Mn` | `Mc` | `Me`  (Short form: `M`)
     pub fn is_mark(&self) -> bool {
+        use self::abbr_names::*;
         matches!(*self, Mn | Mc | Me)
     }
 
     /// `Nd` | `Nl` | `No`  (Short form: `N`)
     pub fn is_number(&self) -> bool {
+        use self::abbr_names::*;
         matches!(*self, Nd | Nl | No)
     }
 
     /// `Pc` | `Pd` | `Ps` | `Pe` | `Pi` | `Pf` | `Po`  (Short form: `P`)
     pub fn is_punctuation(&self) -> bool {
+        use self::abbr_names::*;
         matches!(*self, Pc | Pd | Ps | Pe | Pi | Pf | Po)
     }
 
     /// `Sm` | `Sc` | `Sk` | `So`  (Short form: `S`)
     pub fn is_symbol(&self) -> bool {
+        use self::abbr_names::*;
         matches!(*self, Sm | Sc | Sk | So)
     }
 
     /// `Zs` | `Zl` | `Zp`  (Short form: `Z`)
     pub fn is_separator(&self) -> bool {
+        use self::abbr_names::*;
         matches!(*self, Zs | Zl | Zp)
     }
 
     /// `Cc` | `Cf` | `Cs` | `Co` | `Cn`  (Short form: `C`)
     pub fn is_other(&self) -> bool {
+        use self::abbr_names::*;
         matches!(*self, Cc | Cf | Cs | Co | Cn)
     }
 }

--- a/unic/ucd/normal/src/canonical_combining_class.rs
+++ b/unic/ucd/normal/src/canonical_combining_class.rs
@@ -115,13 +115,17 @@ pub mod values {
 }
 
 
-const CANONICAL_COMBINING_CLASS_VALUES: &'static [(char, char, CanonicalCombiningClass)] =
-    include!("tables/canonical_combining_class_values.rsv");
+mod data {
+    use super::CanonicalCombiningClass;
+    pub const CANONICAL_COMBINING_CLASS_VALUES: &'static [(char, char, CanonicalCombiningClass)] =
+        include!("tables/canonical_combining_class_values.rsv");
+}
+
 
 impl CanonicalCombiningClass {
     /// Find the character *Canonical_Combining_Class* property value.
     pub fn of(ch: char) -> CanonicalCombiningClass {
-        *CANONICAL_COMBINING_CLASS_VALUES.find_or(ch, &CanonicalCombiningClass(0))
+        *data::CANONICAL_COMBINING_CLASS_VALUES.find_or(ch, &CanonicalCombiningClass(0))
     }
 
     /// Human-readable description of the property value.

--- a/unic/ucd/normal/src/composition.rs
+++ b/unic/ucd/normal/src/composition.rs
@@ -12,34 +12,36 @@
 
 use unic_utils::CharDataTable;
 
-use decomposition_type::DecompositionType;
+pub mod data {
+    use DecompositionType;
+    use decomposition_type::long_names::*;
 
-// == Canonical Composition (C) ==
-const CANONICAL_COMPOSITION_MAPPING: &'static [(char, &'static [(char, char)])] =
-    include!("tables/canonical_composition_mapping.rsv");
+    pub const CANONICAL_COMPOSITION_MAPPING: &'static [(char, &'static [(char, char)])] =
+        include!("tables/canonical_composition_mapping.rsv");
+
+    pub const CANONICAL_DECOMPOSITION_MAPPING: &'static [(char, &'static [char])] =
+        include!("tables/canonical_decomposition_mapping.rsv");
+
+    pub const COMPATIBILITY_DECOMPOSITION_MAPPING: &'static [(
+        char,
+        (DecompositionType, &'static [char]),
+    )] = include!("tables/compatibility_decomposition_mapping.rsv");
+}
+
 
 /// Canonical Composition of the character.
 pub fn canonical_composition(c: char) -> Option<&'static ([(char, char)])> {
-    CANONICAL_COMPOSITION_MAPPING.find(c).map(|it| *it)
+    data::CANONICAL_COMPOSITION_MAPPING.find(c).map(|it| *it)
 }
-
-// == Canonical Decomposition (D) ==
-const CANONICAL_DECOMPOSITION_MAPPING: &'static [(char, &'static [char])] =
-    include!("tables/canonical_decomposition_mapping.rsv");
 
 /// Canonical Decomposition of the character.
 pub fn canonical_decomposition(c: char) -> Option<&'static [char]> {
-    CANONICAL_DECOMPOSITION_MAPPING.find(c).map(|it| *it)
+    data::CANONICAL_DECOMPOSITION_MAPPING.find(c).map(|it| *it)
 }
-
-// == Compatibility Decomposition (KD) ==
-use decomposition_type::long_names::*;
-pub const COMPATIBILITY_DECOMPOSITION_MAPPING: &'static [(
-    char,
-    (DecompositionType, &'static [char]),
-)] = include!("tables/compatibility_decomposition_mapping.rsv");
 
 /// Compatibility Decomposition of the character.
 pub fn compatibility_decomposition(c: char) -> Option<&'static [char]> {
-    COMPATIBILITY_DECOMPOSITION_MAPPING.find(c).map(|it| it.1)
+    data::COMPATIBILITY_DECOMPOSITION_MAPPING
+        .find(c)
+        .map(|it| it.1)
 }

--- a/unic/ucd/normal/src/decomposition_type.rs
+++ b/unic/ucd/normal/src/decomposition_type.rs
@@ -15,7 +15,7 @@
 use unic_utils::CharDataTable;
 use unic_char_property::PartialCharProperty;
 
-use composition::{canonical_decomposition, COMPATIBILITY_DECOMPOSITION_MAPPING};
+use composition::{canonical_decomposition, data};
 use hangul;
 
 char_property! {
@@ -164,13 +164,15 @@ impl PartialCharProperty for DecompositionType {
 
 
 impl DecompositionType {
-    /// Find the DecompositionType of a single char.
+    /// Find the DecompositionType of the character.
     pub fn of(ch: char) -> Option<DecompositionType> {
         // First, check for Hangul Syllables and other canonical decompositions
         if hangul::is_syllable(ch) || canonical_decomposition(ch).is_some() {
             return Some(DecompositionType::Canonical);
         }
-        COMPATIBILITY_DECOMPOSITION_MAPPING.find(ch).map(|it| it.0)
+        data::COMPATIBILITY_DECOMPOSITION_MAPPING
+            .find(ch)
+            .map(|it| it.0)
     }
 }
 

--- a/unic/ucd/normal/src/gen_cat.rs
+++ b/unic/ucd/normal/src/gen_cat.rs
@@ -39,7 +39,6 @@ pub use self::mark::is_combining_mark;
 #[cfg(test)]
 mod tests {
     use std::char;
-
     use super::*;
 
     #[test]


### PR DESCRIPTION
the `use ...::*` is considered a bad practice and should be avoided as
much as possible, or limited to the scope where it's needed.

A major case we have needed them in UCD components is when loading data
from `rsv` files, where we don't want to prefix values in every single
line with the type name. To limit the scope of the wildcard usage, I
have moved these to a local `mod data`.