### PR TITLE
[char/property] [ucd] Macro update and use

### DIFF
--- a/unic/bidi/Cargo.toml
+++ b/unic/bidi/Cargo.toml
@@ -29,4 +29,5 @@ unic-ucd-bidi = { path = "../ucd/bidi/", version = "0.5.0" }
 
 [dev-dependencies]
 serde_test = ">=0.8, <2.0"
+unic-char-property = { path = "../char/property/", version = "0.5.0" }
 unic-ucd-core = { path = "../ucd/core/", version = "0.5.0" }

--- a/unic/bidi/tests/conformance_tests.rs
+++ b/unic/bidi/tests/conformance_tests.rs
@@ -13,6 +13,7 @@
 
 
 extern crate unic_bidi;
+extern crate unic_char_property;
 
 
 use unic_bidi::{format_chars, level, BidiClass, BidiInfo, Level};
@@ -279,33 +280,9 @@ fn gen_char_from_bidi_class_abbr(bidi_class_abbr: &str) -> char {
 
 #[test]
 fn test_gen_char_from_bidi_class() {
-    use self::bidi_class::abbr_names::*;
+    use unic_char_property::EnumeratedCharProperty;
 
-    for &class in &[
-        AL,
-        AN,
-        B,
-        BN,
-        CS,
-        EN,
-        ES,
-        ET,
-        FSI,
-        L,
-        LRE,
-        LRI,
-        LRO,
-        NSM,
-        ON,
-        PDF,
-        PDI,
-        R,
-        RLE,
-        RLI,
-        RLO,
-        S,
-        WS,
-    ] {
+    for &class in BidiClass::all_values() {
         let bidi_class_abbr = class.abbr_name();
         let sample_char = gen_char_from_bidi_class_abbr(bidi_class_abbr);
         assert_eq!(BidiClass::of(sample_char), class);

--- a/unic/bidi/tests/conformance_tests.rs
+++ b/unic/bidi/tests/conformance_tests.rs
@@ -15,7 +15,7 @@
 extern crate unic_bidi;
 
 
-use unic_bidi::{bidi_class, format_chars, level, BidiClass, BidiInfo, Level};
+use unic_bidi::{format_chars, level, BidiClass, BidiInfo, Level};
 
 
 const BASIC_TEST_DATA: &'static str = include_str!("../../../data/ucd/test/BidiTest.txt");

--- a/unic/char/property/src/macros.rs
+++ b/unic/char/property/src/macros.rs
@@ -29,7 +29,6 @@
 ///         RustName {
 ///             abbr => AbbrName,
 ///             long => Long_Name,
-///             // human is optional and may be included on _all_ traits or left off of _all_ traits
 ///             human => "&'static str that is a nicer presentation of the name",
 ///         }
 ///     }
@@ -53,6 +52,7 @@
 ///
 /// - Implements the `CharProperty` trait and appropriate range trait
 /// - Implements `FromStr` accepting either the abbr or long name, ascii case insensitive
+/// - Implements `Display` using the `human` string
 /// - Populates the module `abbr_names` with `pub use` bindings of variants to their abbr names
 /// - Populates the module `long_names` with `pub use` bindings of variants to their long names
 /// - Maintains all documentation comments and other `#[attributes]` as would be expected

--- a/unic/char/property/src/macros.rs
+++ b/unic/char/property/src/macros.rs
@@ -21,16 +21,16 @@
 /// char_property! {
 ///     /// This is the enum type created for the character property.
 ///     pub enum MyProp {
+///         abbr => "AbbrPropName";
+///         long => "Long_Property_Name";
+///         human => "Human-Readable Property Name";
+///
 ///         /// Exactly one attribute
 ///         RustName {
 ///             abbr => AbbrName,
 ///             long => Long_Name,
-///             display => "&'static str that is a nicer presentation of the name",
-///         }
-///
-///         /// All annotations on the variant are optional*
-///         Variant2 {
-///             abbr => V2, // *abbr is required for Enumerated Properties
+///             // human is optional and may be included on _all_ traits or left off of _all_ traits
+///             human => "&'static str that is a nicer presentation of the name",
 ///         }
 ///     }
 ///
@@ -41,14 +41,7 @@
 ///     pub mod long_names for long;
 /// }
 ///
-/// // We also need to impl `CharProperty`, and `PartialCharProperty` or `CompleteCharProperty`
-/// // manually.
-/// # // TODO: impl CharProperty by the macro.
-/// # impl unic_char_property::CharProperty for MyProp {
-/// #     fn prop_abbr_name() -> &'static str { "myprop" }
-/// #     fn prop_long_name() -> &'static str { "MyProp" }
-/// #     fn prop_human_name() -> &'static str { "MyProp" }
-/// # }
+/// // We also need to impl `PartialCharProperty` or `CompleteCharProperty` manually.
 /// # impl unic_char_property::PartialCharProperty for MyProp {
 /// #     fn of(_: char) -> Option<Self> { None }
 /// # }
@@ -58,244 +51,43 @@
 ///
 /// # Effect
 ///
-/// - Implements `CharProperty` with the `abbr` and `long` presented in the appropriate method
-/// - Implements `FromStr` accepting any of the rust, abbr, or long names
-/// - Implements `Display` using the given string, falling back when not provided on
-///   the long name, the short name, and the rust name, in that order
+/// - Implements the `CharProperty` trait and appropriate range trait
+/// - Implements `FromStr` accepting either the abbr or long name, ascii case insensitive
 /// - Populates the module `abbr_names` with `pub use` bindings of variants to their abbr names
 /// - Populates the module `long_names` with `pub use` bindings of variants to their long names
 /// - Maintains all documentation comments and other `#[attributes]` as would be expected
-///   (with some caveats, listed below)
+///   (with some limitations, listed below)
 ///
 /// # Limitations
 ///
-/// Due to [rust-lang/rust/#24189](https://github.com/rust-lang/rust/issues/24189), (fixed in
-/// [rust-lang/rust/#42913](https://github.com/rust-lang/rust/pull/42913), landing in 1.20),
+/// Due to [rust-lang/rust#24189](https://github.com/rust-lang/rust/issues/24189), (fixed in
+/// [rust-lang/rust#42913](https://github.com/rust-lang/rust/pull/42913), landing in 1.20),
 /// exactly one attribute line must be used on each variant.
 ///
-/// On 1.20 or higher, one or more may be used, and the restriction can be relaxed back the intended
-/// zero or more by replacing
-/// - `$(#[$variant_meta:meta])+` with `$(#[$variant_meta:meta])*`,
-/// - `$(#[$variant_meta])+` with `$(#[$variant_meta])*`,
-/// - `$(#[$ident_meta:meta])+` with `$(#[$ident_meta:meta])*`
-/// - `$(#[$ident_meta])+` with `$(#[$ident_meta])*`,
-/// - `$(#[$rest_meta:meta])+` with `$(#[$rest_meta:meta])*`,
-/// - `$(#[$rest_meta])+` with `$(#[$rest_meta])*`,
-/// - `$(#[$queue_meta:meta])+` with `$(#[$queue_meta:meta])*`, and
-/// - `$(#[$queue_meta])+` with `$(#[$queue_meta])*`.
+/// On 1.20 or higher, one or more may be used, and the restriction can be relaxed back to
+/// the intended zero or more by replacing `$(#[$variant_meta:meta])+` with
+/// `$(#[$variant_meta:meta])*` and `$(#[$variant_meta])+` with `$(#[$variant_meta])*`.
 // TODO: Once adopting 1.20, fix the macro to work with zero attributes on variants (see above)
 #[macro_export]
 macro_rules! char_property {
     (
         $(#[$name_meta:meta])* pub enum $name:ident {
-            $( $(#[$variant_meta:meta])+ $variant:ident $tt:tt )*
+            abbr => $abbr_name:expr;
+            long => $long_name:expr;
+            human => $human_name:expr;
+
+            $(
+                $(#[$variant_meta:meta])+
+                $variant:ident {
+                    abbr => $abbr:ident,
+                    long => $long:ident,
+                    human => $human:expr,
+                }
+            )*
         }
 
-        $(#[$abbr_names_meta:meta])* pub mod $abbr_names:ident for abbr;
-        $(#[$long_names_meta:meta])* pub mod $long_names:ident for long;
-    ) => {
-        __char_property_internal! {
-            $(#[$name_meta])* pub enum $name
-            $(#[$abbr_names_meta])* pub mod $abbr_names
-            $(#[$long_names_meta])* pub mod $long_names
-
-            variant [ ]
-            abbr [ ]
-            long [ ]
-            display [ ]
-
-            buffer [ ]
-            queue [ $( $(#[$variant_meta])+ $variant $tt )* ]
-        }
-    };
-}
-
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __char_property_internal {
-    // == Queue => Buffer == //
-    (
-        $(#[$name_meta:meta])* pub enum $name:ident
-        $(#[$abbr_names_meta:meta])* pub mod $abbr_names:ident
-        $(#[$long_names_meta:meta])* pub mod $long_names:ident
-
-        variant [ $( $(#[$variant_meta:meta])+ $variant:ident ; )* ]
-        abbr [ $( $abbr_variant:ident $abbr:ident ; )* ]
-        long [ $( $long_variant:ident $long:ident ; )* ]
-        display [ $( $display_variant:ident $display:expr ; )* ]
-
-        buffer [  ]
-        queue [
-            $(#[$ident_meta:meta])+ $ident:ident $ident_tt:tt
-            $( $(#[$rest_meta:meta])+ $rest:ident $rest_tt:tt )*
-        ]
-    ) => {
-        __char_property_internal! {
-            $(#[$name_meta])* pub enum $name
-            $(#[$abbr_names_meta])* pub mod $abbr_names
-            $(#[$long_names_meta])* pub mod $long_names
-
-            variant [
-                $( $(#[$variant_meta])+ $variant ; )*
-                $(#[$ident_meta])+ $ident ;
-            ]
-            abbr [ $( $abbr_variant $abbr ; )* ]
-            long [ $( $long_variant $long ; )* ]
-            display [ $( $display_variant $display ; )* ]
-
-            buffer [ $ident $ident_tt ]
-            queue [ $( $(#[$rest_meta])+ $rest $rest_tt )* ]
-        }
-    };
-
-    // == Buffer -- Abbr Name == //
-    (
-        $(#[$name_meta:meta])* pub enum $name:ident
-        $(#[$abbr_names_meta:meta])* pub mod $abbr_names:ident
-        $(#[$long_names_meta:meta])* pub mod $long_names:ident
-
-        variant [ $( $(#[$variant_meta:meta])+ $variant:ident ; )* ]
-        abbr [ $( $abbr_variant:ident $abbr:ident ; )* ]
-        long [ $( $long_variant:ident $long:ident ; )* ]
-        display [ $( $display_variant:ident $display:expr ; )* ]
-
-        buffer [ $ident:ident {
-            abbr => $ident_abbr:ident ,
-            $( $rest:tt )*
-        } ]
-        queue [ $( $(#[$queue_meta:meta])+ $queue:ident $queue_tt:tt )* ]
-    ) => {
-        __char_property_internal! {
-            $(#[$name_meta])* pub enum $name
-            $(#[$abbr_names_meta])* pub mod $abbr_names
-            $(#[$long_names_meta])* pub mod $long_names
-
-            variant [ $( $(#[$variant_meta])+ $variant ; )* ]
-            abbr [
-                $( $abbr_variant $abbr ; )*
-                $ident $ident_abbr ;
-            ]
-            long [ $( $long_variant $long ; )* ]
-            display [ $( $display_variant $display ; )* ]
-
-            buffer [ $ident { $( $rest )* } ]
-            queue [ $( $(#[$queue_meta])+ $queue $queue_tt )* ]
-        }
-    };
-
-    // == Buffer -- Long Name == //
-    (
-        $(#[$name_meta:meta])* pub enum $name:ident
-        $(#[$abbr_names_meta:meta])* pub mod $abbr_names:ident
-        $(#[$long_names_meta:meta])* pub mod $long_names:ident
-
-        variant [ $( $(#[$variant_meta:meta])+ $variant:ident ; )* ]
-        abbr [ $( $abbr_variant:ident $abbr:ident ; )* ]
-        long [ $( $long_variant:ident $long:ident ; )* ]
-        display [ $( $display_variant:ident $display:expr ; )* ]
-
-        buffer [ $ident:ident {
-            long => $ident_long:ident ,
-            $( $rest:tt )*
-        } ]
-        queue [ $( $(#[$queue_meta:meta])+ $queue:ident $queue_tt:tt )* ]
-    ) => {
-        __char_property_internal! {
-            $(#[$name_meta])* pub enum $name
-            $(#[$abbr_names_meta])* pub mod $abbr_names
-            $(#[$long_names_meta])* pub mod $long_names
-
-            variant [ $( $(#[$variant_meta])+ $variant ; )* ]
-            abbr [ $( $abbr_variant $abbr ; )* ]
-            long [
-                $( $long_variant $long ; )*
-                $ident $ident_long ;
-            ]
-            display [ $( $display_variant $display ; )* ]
-
-            buffer [ $ident { $( $rest )* } ]
-            queue [ $( $(#[$queue_meta])+ $queue $queue_tt )* ]
-        }
-    };
-
-    // == Buffer -- Display //
-    (
-        $(#[$name_meta:meta])* pub enum $name:ident
-        $(#[$abbr_names_meta:meta])* pub mod $abbr_names:ident
-        $(#[$long_names_meta:meta])* pub mod $long_names:ident
-
-        variant [ $( $(#[$variant_meta:meta])+ $variant:ident ; )* ]
-        abbr [ $( $abbr_variant:ident $abbr:ident ; )* ]
-        long [ $( $long_variant:ident $long:ident ; )* ]
-        display [ $( $display_variant:ident $display:expr ; )* ]
-
-        buffer [ $ident:ident {
-            display => $ident_display:expr ,
-            $( $rest:tt )*
-        } ]
-        queue [ $( $(#[$queue_meta:meta])+ $queue:ident $queue_tt:tt )* ]
-    ) => {
-        __char_property_internal! {
-            $(#[$name_meta])* pub enum $name
-            $(#[$abbr_names_meta])* pub mod $abbr_names
-            $(#[$long_names_meta])* pub mod $long_names
-
-            variant [ $( $(#[$variant_meta])+ $variant ; )* ]
-            abbr [ $( $abbr_variant $abbr ; )* ]
-            long [ $( $long_variant $long ; )* ]
-            display [
-                $( $display_variant $display ; )*
-                $ident $ident_display ;
-            ]
-
-            buffer [ $ident { $( $rest )* } ]
-            queue [ $( $(#[$queue_meta])+ $queue $queue_tt )* ]
-        }
-    };
-
-    // == Buffer -- Empty == //
-    (
-        $(#[$name_meta:meta])* pub enum $name:ident
-        $(#[$abbr_names_meta:meta])* pub mod $abbr_names:ident
-        $(#[$long_names_meta:meta])* pub mod $long_names:ident
-
-        variant [ $( $(#[$variant_meta:meta])+ $variant:ident ; )* ]
-        abbr [ $( $abbr_variant:ident $abbr:ident ; )* ]
-        long [ $( $long_variant:ident $long:ident ; )* ]
-        display [ $( $display_variant:ident $display:expr ; )* ]
-
-        buffer [ $ident:ident {} ]
-        queue [ $( $(#[$queue_meta:meta])+ $queue:ident $queue_tt:tt )* ]
-    ) => {
-        __char_property_internal! {
-            $(#[$name_meta])* pub enum $name
-            $(#[$abbr_names_meta])* pub mod $abbr_names
-            $(#[$long_names_meta])* pub mod $long_names
-
-            variant [ $( $(#[$variant_meta])+ $variant ; )* ]
-            abbr [ $( $abbr_variant $abbr ; )* ]
-            long [ $( $long_variant $long ; )* ]
-            display [ $( $display_variant $display ; )* ]
-
-            buffer [ ]
-            queue [ $( $(#[$queue_meta])+ $queue $queue_tt )* ]
-        }
-    };
-
-    // == Final formatting == //
-    (
-        $(#[$name_meta:meta])* pub enum $name:ident
-        $(#[$abbr_names_meta:meta])* pub mod $abbr_names:ident
-        $(#[$long_names_meta:meta])* pub mod $long_names:ident
-
-        variant [ $( $(#[$variant_meta:meta])+ $variant:ident ; )* ]
-        abbr [ $( $abbr_variant:ident $abbr:ident ; )* ]
-        long [ $( $long_variant:ident $long:ident ; )* ]
-        display [ $( $display_variant:ident $display:expr ; )* ]
-
-        buffer [ ]
-        queue [ ]
+        $(#[$abbr_mod_meta:meta])* pub mod $abbr_mod:ident for abbr;
+        $(#[$long_mod_meta:meta])* pub mod $long_mod:ident for long;
     ) => {
         $(#[$name_meta])*
         #[allow(bad_style)]
@@ -304,84 +96,74 @@ macro_rules! __char_property_internal {
             $( $(#[$variant_meta])+ $variant, )*
         }
 
-        $(#[$abbr_names_meta])*
+        $(#[$abbr_mod_meta])*
         #[allow(bad_style)]
-        pub mod $abbr_names {
-            $( pub use super::$name::$abbr_variant as $abbr; )*
+        pub mod $abbr_mod {
+            $( pub use super::$name::$variant as $abbr; )*
         }
 
-        $(#[$long_names_meta])*
+        $(#[$long_mod_meta])*
         #[allow(bad_style)]
-        pub mod $long_names {
-            $( pub use super::$name::$long_variant as $long; )*
+        pub mod $long_mod {
+            $( pub use super::$name::$variant as $long; )*
         }
 
-        #[allow(bad_style)]
         #[allow(unreachable_patterns)]
         impl ::std::str::FromStr for $name {
             type Err = ();
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 match s {
-                    $( stringify!($variant) => Ok($name::$variant), )*
-                    $( stringify!($abbr) => Ok($name::$abbr_variant), )*
-                    $( stringify!($long) => Ok($name::$long_variant), )*
-                    $( str
-                        if ::std::ascii::AsciiExt::eq_ignore_ascii_case(str, stringify!($variant))
-                        => Ok($name::$variant),
-                     )*
-                    $( str
-                        if ::std::ascii::AsciiExt::eq_ignore_ascii_case(str, stringify!($abbr))
-                        => Ok($name::$abbr_variant),
-                     )*
-                    $( str
-                        if ::std::ascii::AsciiExt::eq_ignore_ascii_case(str, stringify!($long))
-                        => Ok($name::$long_variant),
-                     )*
+                    $(
+                        stringify!($abbr) => Ok($name::$variant),
+                        stringify!($long) => Ok($name::$variant),
+                    )*
+                    $(
+                        str if ::std::ascii::AsciiExt::eq_ignore_ascii_case(str, stringify!($abbr))
+                            => Ok($name::$variant),
+                        str if ::std::ascii::AsciiExt::eq_ignore_ascii_case(str, stringify!($long))
+                            => Ok($name::$variant),
+                    )*
                     _ => Err(()),
                 }
             }
         }
 
-        #[allow(bad_style)]
-        #[allow(unreachable_patterns)]
-        impl ::std::fmt::Display for $name {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                match *self {
-                    $( $name::$display_variant => write!(f, "{}", $display), )*
-                    $( $name::$long_variant
-                        => write!(f, "{}", stringify!($long).replace('_', " ")),
-                     )*
-                    _ => write!(f, "{}", match *self {
-                        $( $name::$abbr_variant => stringify!($abbr), )*
-                        $( $name::$variant => stringify!($variant), )*
-                    })
-                }
-            }
+        impl $crate::CharProperty for $name {
+            fn prop_abbr_name() -> &'static str { $abbr_name }
+            fn prop_long_name() -> &'static str { $long_name }
+            fn prop_human_name() -> &'static str { $human_name }
         }
 
-        #[allow(bad_style)]
         impl $crate::EnumeratedCharProperty for $name {
-            fn abbr_name(&self) -> &'static str {
-                match *self {
-                    $( $name::$abbr_variant => stringify!($abbr), )*
-                    // No catch all variant
-                    // Abbr name is required on Enumerated properties
-                }
-            }
-
-            fn long_name(&self) -> &'static str {
-                "FIXME"
-            }
-
-            fn human_name(&self) -> &'static str {
-                "FIXME"
-            }
-
             fn all_values() -> &'static [$name] {
                 const VALUES: &[$name] = &[
                     $($name::$variant,)+
                 ];
                 VALUES
+            }
+
+            fn abbr_name(&self) -> &'static str {
+                match *self {
+                    $( $name::$variant => stringify!($abbr), )*
+                }
+            }
+
+            fn long_name(&self) -> &'static str {
+                match *self {
+                    $( $name::$variant => stringify!($long), )*
+                }
+            }
+
+            fn human_name(&self) -> &'static str {
+                match *self {
+                    $( $name::$variant => $human, )*
+                }
+            }
+        }
+
+        impl ::std::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                $crate::EnumeratedCharProperty::human_name(self).fmt(f)
             }
         }
     };

--- a/unic/char/property/tests/macro_tests.rs
+++ b/unic/char/property/tests/macro_tests.rs
@@ -13,49 +13,39 @@
 extern crate unic_char_property;
 
 
-use unic_char_property::{CharProperty, PartialCharProperty};
+use unic_char_property::PartialCharProperty;
 
 
 char_property! {
     pub enum MyProp {
+        abbr => "mp";
+        long => "My_Prop";
+        human => "My Property";
+
         /// Required
-        AbbrVariant {
-            abbr => AV,
+        Variant1 {
+            abbr => V1,
+            long => Variant_1,
+            human => "Variant 1",
         }
+
         /// Required
-        LongVariant {
-            abbr => LV,
-            long => Long_Variant,
+        Variant2 {
+            abbr => V2,
+            long => Variant_2,
+            human => "Variant 2",
         }
+
         /// Required
-        DisplayVariant {
-            abbr => DV,
-            display => "The one and only DISPLAY VARIANT!",
-        }
-        /// Required
-        EmptyVariant {
-            abbr => EV,
+        Variant3 {
+            abbr => V3,
+            long => Variant_3,
+            human => "Variant 3",
         }
     }
 
-    pub mod abbr_names for abbr;
-    pub mod long_names for long;
-}
-
-
-// TODO: Impl by char_property!()
-impl CharProperty for MyProp {
-    fn prop_abbr_name() -> &'static str {
-        "myprop"
-    }
-
-    fn prop_long_name() -> &'static str {
-        "MyProp"
-    }
-
-    fn prop_human_name() -> &'static str {
-        "MyProp"
-    }
+    pub mod abbr for abbr;
+    pub mod long for long;
 }
 
 
@@ -70,33 +60,33 @@ impl PartialCharProperty for MyProp {
 fn basic_macro_use() {
     use unic_char_property::EnumeratedCharProperty;
 
-    assert_eq!(MyProp::AbbrVariant, abbr_names::AV);
-    assert_eq!(MyProp::LongVariant, abbr_names::LV);
-    assert_eq!(MyProp::DisplayVariant, abbr_names::DV);
-    assert_eq!(MyProp::EmptyVariant, abbr_names::EV);
+    assert_eq!(MyProp::Variant1, abbr::V1);
+    assert_eq!(MyProp::Variant2, abbr::V2);
+    assert_eq!(MyProp::Variant3, abbr::V3);
 
-    assert_eq!(MyProp::LongVariant, long_names::Long_Variant);
+    assert_eq!(MyProp::Variant1, long::Variant_1);
+    assert_eq!(MyProp::Variant2, long::Variant_2);
+    assert_eq!(MyProp::Variant3, long::Variant_3);
 
-    assert_eq!(MyProp::AbbrVariant.abbr_name(), "AV");
-    assert_eq!(MyProp::LongVariant.abbr_name(), "LV");
-    assert_eq!(MyProp::DisplayVariant.abbr_name(), "DV");
-    assert_eq!(MyProp::EmptyVariant.abbr_name(), "EV");
+    assert_eq!(MyProp::Variant1.abbr_name(), "V1");
+    assert_eq!(MyProp::Variant2.abbr_name(), "V2");
+    assert_eq!(MyProp::Variant3.abbr_name(), "V3");
 
-    assert_eq!(format!("{}", MyProp::AbbrVariant), "AV");
-    assert_eq!(format!("{}", MyProp::LongVariant), "Long Variant");
-    assert_eq!(
-        format!("{}", MyProp::DisplayVariant),
-        "The one and only DISPLAY VARIANT!"
-    );
-    assert_eq!(format!("{}", MyProp::EmptyVariant), "EV");
+    assert_eq!(MyProp::Variant1.long_name(), "Variant_1");
+    assert_eq!(MyProp::Variant2.long_name(), "Variant_2");
+    assert_eq!(MyProp::Variant3.long_name(), "Variant_3");
+
+    assert_eq!(MyProp::Variant1.human_name(), "Variant 1");
+    assert_eq!(MyProp::Variant2.human_name(), "Variant 2");
+    assert_eq!(MyProp::Variant3.human_name(), "Variant 3");
 }
 
 #[test]
 fn fromstr_ignores_case() {
-    use abbr_names::LV;
+    use abbr::V1;
 
-    assert_eq!("long_variant".parse(), Ok(LV));
-    assert_eq!("lOnG_vArIaNt".parse(), Ok(LV));
-    assert_eq!("LoNg_VaRiAnT".parse(), Ok(LV));
-    assert_eq!("LONG_VARIANT".parse(), Ok(LV));
+    assert_eq!("variant_1".parse(), Ok(V1));
+    assert_eq!("VaRiAnT_1".parse(), Ok(V1));
+    assert_eq!("vArIaNt_1".parse(), Ok(V1));
+    assert_eq!("VARIANT_1".parse(), Ok(V1));
 }

--- a/unic/ucd/bidi/src/bidi_class.rs
+++ b/unic/ucd/bidi/src/bidi_class.rs
@@ -10,60 +10,201 @@
 // except according to those terms.
 
 
-use std::fmt;
-
 use unic_utils::CharDataTable;
-use unic_char_property::{CharProperty, CompleteCharProperty, EnumeratedCharProperty};
+use unic_char_property::CompleteCharProperty;
 
 
-/// Represents the Unicode character
-/// [*Bidi_Class*](http://www.unicode.org/reports/tr44/#Bidi_Class) property, also known as the
-/// *bidirectional character type*.
-///
-/// * <http://www.unicode.org/reports/tr9/#Bidirectional_Character_Types>
-/// * <http://www.unicode.org/reports/tr44/#Bidi_Class_Values>
-#[derive(Clone, Copy, Eq, PartialEq, Debug, Hash)]
-#[allow(missing_docs)]
-pub enum BidiClass {
-    ArabicLetter,
-    ArabicNumber,
-    ParagraphSeparator,
-    BoundaryNeutral,
-    CommonSeparator,
-    EuropeanNumber,
-    EuropeanSeparator,
-    EuropeanTerminator,
-    FirstStrongIsolate,
-    LeftToRight,
-    LeftToRightEmbedding,
-    LeftToRightIsolate,
-    LeftToRightOverride,
-    NonspacingMark,
-    OtherNeutral,
-    PopDirectionalFormat,
-    PopDirectionalIsolate,
-    RightToLeft,
-    RightToLeftEmbedding,
-    RightToLeftIsolate,
-    RightToLeftOverride,
-    SegmentSeparator,
-    WhiteSpace,
-    // [UNIC_UPDATE_ON_UNICODE_UPDATE] Source: `tables/bidi_class_type.rsv`
-}
+char_property! {
+    /// Represents the Unicode character
+    /// [*Bidi_Class*](http://www.unicode.org/reports/tr44/#Bidi_Class) property, also known as the
+    /// *bidirectional character type*.
+    ///
+    /// * <http://www.unicode.org/reports/tr9/#Bidirectional_Character_Types>
+    /// * <http://www.unicode.org/reports/tr44/#Bidi_Class_Values>
+    pub enum BidiClass {
+        abbr => "bc";
+        long => "Bidi_Class";
+        human => "Bidirectional Class";
 
+        /// A strong Right-to-Left (Arabic-type) character
+        ArabicLetter {
+            abbr => AL,
+            long => Arabic_Letter,
+            human => "Right-to-Left Arabic",
+        }
 
-impl CharProperty for BidiClass {
-    fn prop_abbr_name() -> &'static str {
-        "bc"
+        /// A (non-Eastern) Arabic-Indic digit
+        ArabicNumber {
+            abbr => AN,
+            long => Arabic_Number,
+            human => "Arabic Number",
+        }
+
+        /// A newline character
+        ParagraphSeparator {
+            abbr => B,
+            long => Paragraph_Separator,
+            human => "Paragraph Separator",
+        }
+
+        /// Most format characters, control codes, and noncharacters
+        BoundaryNeutral {
+            abbr => BN,
+            long => Boundary_Neutral,
+            human => "Neutral Boundary",
+        }
+
+        /// A comma, colon, or slash
+        CommonSeparator {
+            abbr => CS,
+            long => Common_Separator,
+            human => "Common Number Separator",
+        }
+
+        /// A ASCII digit or Eastern Arabic-Indic digit
+        EuropeanNumber {
+            abbr => EN,
+            long => European_Number,
+            human => "European Number",
+        }
+
+        /// A plus or minus sign
+        EuropeanSeparator {
+            abbr => ES,
+            long => European_Separator,
+            human => "European Number Separator",
+        }
+
+        /// A terminator in a numeric format context (including currency signs)
+        EuropeanTerminator {
+            abbr => ET,
+            long => European_Terminator,
+            human => "European Number Terminator",
+        }
+
+        /// U+2068: The first strong isolate control
+        FirstStrongIsolate {
+            abbr => FSI,
+            long => First_Strong_Isolate,
+            human => "First Strong Isolate",
+        }
+
+        /// A strong Left-to-Right character
+        LeftToRight {
+            abbr => L,
+            long => Left_To_Right,
+            human => "Left-to-Right",
+        }
+
+        /// U+202A: the Left-to-Right embedding control
+        LeftToRightEmbedding {
+            abbr => LRE,
+            long => Left_To_Right_Embedding,
+            human => "Left-to-Right Embedding",
+        }
+
+        /// U+2066: the Left-to-Right isolate control
+        LeftToRightIsolate {
+            abbr => LRI,
+            long => Left_To_Right_Isolate,
+            human => "Left-to-Right Isolate",
+        }
+
+        /// U+202D: the Left-to-Right override control
+        LeftToRightOverride {
+            abbr => LRO,
+            long => Left_To_Right_Override,
+            human => "LeftToRightOverride",
+        }
+
+        /// A nonspacing mark
+        NonspacingMark {
+            abbr => NSM,
+            long => Nonspacing_Mark,
+            human => "Nonspacing Mark",
+        }
+
+        /// Symbols and Punctuation not in a different category
+        OtherNeutral {
+            abbr => ON,
+            long => Other_Neutral,
+            human => "OtherNeutral",
+        }
+
+        /// U+202C: terminates an embedding or override control
+        PopDirectionalFormat {
+            abbr => PDF,
+            long => Pop_Directional_Format,
+            human => "Pop Directional Format",
+        }
+
+        /// U+2069: terminates an isolate control
+        PopDirectionalIsolate {
+            abbr => PDI,
+            long => Pop_Directional_Isolate,
+            human => "PopDirectionalIsolate",
+        }
+
+        /// A strong Right-to-Left (non-Arabic-type) character
+        RightToLeft {
+            abbr => R,
+            long => Right_To_Left,
+            human => "Right-to-Left",
+        }
+
+        /// U+202B: The Right-to-Left embedding control
+        RightToLeftEmbedding {
+            abbr => RLE,
+            long => Right_To_Left_Embedding,
+            human => "Right-to-Left Embedding",
+        }
+
+        /// U+2067: The Right-to-Left isolate control
+        RightToLeftIsolate {
+            abbr => RLI,
+            long => Right_To_Left_Isolate,
+            human => "Right-to-Left Isolate",
+        }
+
+        /// U+202E: The Right-to-Left override control
+        RightToLeftOverride {
+            abbr => RLO,
+            long => Right_To_Left_Override,
+            human => "Right-to-Left Override",
+        }
+
+        /// A segment-related control code
+        SegmentSeparator {
+            abbr => S,
+            long => Segment_Separator,
+            human => "Segment Separator",
+        }
+
+        /// Whitespace
+        WhiteSpace {
+            abbr => WS,
+            long => White_Space,
+            human => "Whitespace",
+        }
     }
 
-    fn prop_long_name() -> &'static str {
-        "Bidi_Class"
-    }
+    /// Abbreviated name aliases for the
+    /// [*Bidi_Class*](http://www.unicode.org/reports/tr44/#Bidi_Class) property.
+    ///
+    /// ## See Also
+    ///
+    /// - <http://www.unicode.org/reports/tr44/#Bidi_Class_Values>
+    /// - <http://www.unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt#Bidi_Class>
+    pub mod abbr_names for abbr;
 
-    fn prop_human_name() -> &'static str {
-        "Bidi Class"
-    }
+    /// Long name aliases for the
+    /// [*Bidi_Class*](http://www.unicode.org/reports/tr44/#Bidi_Class) property.
+    ///
+    /// ## See Also
+    ///
+    /// - <http://www.unicode.org/reports/tr44/#Bidi_Class_Values>
+    /// - <http://www.unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt#Bidi_Class>
+    pub mod long_names for long;
 }
 
 
@@ -74,53 +215,10 @@ impl CompleteCharProperty for BidiClass {
 }
 
 
-impl EnumeratedCharProperty for BidiClass {
-    fn all_values() -> &'static [Self] {
-        Self::all_values()
+impl Default for BidiClass {
+    fn default() -> Self {
+        BidiClass::LeftToRight
     }
-
-    fn abbr_name(&self) -> &'static str {
-        self.abbr_name()
-    }
-
-    fn long_name(&self) -> &'static str {
-        self.long_name()
-    }
-
-    fn human_name(&self) -> &'static str {
-        self.human_name()
-    }
-}
-
-
-/// Abbreviated name aliases for
-/// [*Bidi_Class*](http://www.unicode.org/reports/tr44/#Bidi_Class) property.
-///
-/// <http://www.unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt#Bidi_Class>
-pub mod abbr_names {
-    pub use BidiClass::ArabicLetter as AL;
-    pub use BidiClass::ArabicNumber as AN;
-    pub use BidiClass::ParagraphSeparator as B;
-    pub use BidiClass::BoundaryNeutral as BN;
-    pub use BidiClass::CommonSeparator as CS;
-    pub use BidiClass::EuropeanNumber as EN;
-    pub use BidiClass::EuropeanSeparator as ES;
-    pub use BidiClass::EuropeanTerminator as ET;
-    pub use BidiClass::FirstStrongIsolate as FSI;
-    pub use BidiClass::LeftToRight as L;
-    pub use BidiClass::LeftToRightEmbedding as LRE;
-    pub use BidiClass::LeftToRightIsolate as LRI;
-    pub use BidiClass::LeftToRightOverride as LRO;
-    pub use BidiClass::NonspacingMark as NSM;
-    pub use BidiClass::OtherNeutral as ON;
-    pub use BidiClass::PopDirectionalFormat as PDF;
-    pub use BidiClass::PopDirectionalIsolate as PDI;
-    pub use BidiClass::RightToLeft as R;
-    pub use BidiClass::RightToLeftEmbedding as RLE;
-    pub use BidiClass::RightToLeftIsolate as RLI;
-    pub use BidiClass::RightToLeftOverride as RLO;
-    pub use BidiClass::SegmentSeparator as S;
-    pub use BidiClass::WhiteSpace as WS;
 }
 
 
@@ -129,8 +227,8 @@ use self::abbr_names::*;
 const BIDI_CLASS_TABLE: &'static [(char, char, BidiClass)] =
     include!("tables/bidi_class_values.rsv");
 
-/// Represents **Category** of Unicode character `Bidi_Class` property, as demostrated under "Table
-/// 4. Bidirectional Character Types".
+/// Represents the **Category** of the Unicode character property `Bidi_Class`,
+/// as demonstrated under "Table 4. Bidirectional Character Types".
 ///
 /// * <http://www.unicode.org/reports/tr9/#Table_Bidirectional_Character_Types>
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -153,132 +251,7 @@ impl BidiClass {
     pub fn of(ch: char) -> BidiClass {
         // UCD/extracted/DerivedBidiClass.txt: "All code points not explicitly listed
         // for Bidi_Class have the value Left_To_Right (L)."
-        *BIDI_CLASS_TABLE.find_or(ch, &L)
-    }
-
-    /// Exhaustive list of all `BidiClass` property values.
-    pub fn all_values() -> &'static [BidiClass] {
-        const ALL_VALUES: &[BidiClass] = &[
-            BidiClass::ArabicLetter,
-            BidiClass::ArabicNumber,
-            BidiClass::ParagraphSeparator,
-            BidiClass::BoundaryNeutral,
-            BidiClass::CommonSeparator,
-            BidiClass::EuropeanNumber,
-            BidiClass::EuropeanSeparator,
-            BidiClass::EuropeanTerminator,
-            BidiClass::FirstStrongIsolate,
-            BidiClass::LeftToRight,
-            BidiClass::LeftToRightEmbedding,
-            BidiClass::LeftToRightIsolate,
-            BidiClass::LeftToRightOverride,
-            BidiClass::NonspacingMark,
-            BidiClass::OtherNeutral,
-            BidiClass::PopDirectionalFormat,
-            BidiClass::PopDirectionalIsolate,
-            BidiClass::RightToLeft,
-            BidiClass::RightToLeftEmbedding,
-            BidiClass::RightToLeftIsolate,
-            BidiClass::RightToLeftOverride,
-            BidiClass::SegmentSeparator,
-            BidiClass::WhiteSpace,
-        ];
-        ALL_VALUES
-    }
-
-    /// The *abbreviated name* of the property value.
-    pub fn abbr_name(&self) -> &'static str {
-        match *self {
-            BidiClass::ArabicLetter => "AL",
-            BidiClass::ArabicNumber => "AN",
-            BidiClass::ParagraphSeparator => "B",
-            BidiClass::BoundaryNeutral => "BN",
-            BidiClass::CommonSeparator => "CS",
-            BidiClass::EuropeanNumber => "EN",
-            BidiClass::EuropeanSeparator => "ES",
-            BidiClass::EuropeanTerminator => "ET",
-            BidiClass::FirstStrongIsolate => "FSI",
-            BidiClass::LeftToRight => "L",
-            BidiClass::LeftToRightEmbedding => "LRE",
-            BidiClass::LeftToRightIsolate => "LRI",
-            BidiClass::LeftToRightOverride => "LRO",
-            BidiClass::NonspacingMark => "NSM",
-            BidiClass::OtherNeutral => "ON",
-            BidiClass::PopDirectionalFormat => "PDF",
-            BidiClass::PopDirectionalIsolate => "PDI",
-            BidiClass::RightToLeft => "R",
-            BidiClass::RightToLeftEmbedding => "RLE",
-            BidiClass::RightToLeftIsolate => "RLI",
-            BidiClass::RightToLeftOverride => "RLO",
-            BidiClass::SegmentSeparator => "S",
-            BidiClass::WhiteSpace => "WS",
-        }
-    }
-
-    /// The *long name* of the property value.
-    pub fn long_name(&self) -> &'static str {
-        match *self {
-            BidiClass::ArabicLetter => "Arabic_Letter",
-            BidiClass::ArabicNumber => "Arabic_Number",
-            BidiClass::ParagraphSeparator => "Paragraph_Separator",
-            BidiClass::BoundaryNeutral => "Boundary_Neutral",
-            BidiClass::CommonSeparator => "Common_Separator",
-            BidiClass::EuropeanNumber => "European_Number",
-            BidiClass::EuropeanSeparator => "European_Separator",
-            BidiClass::EuropeanTerminator => "European_Terminator",
-            BidiClass::FirstStrongIsolate => "First_Strong_Isolate",
-            BidiClass::LeftToRight => "Left_To_Right",
-            BidiClass::LeftToRightEmbedding => "Left_To_Right_Embedding",
-            BidiClass::LeftToRightIsolate => "Left_To_Right_Isolate",
-            BidiClass::LeftToRightOverride => "Left_To_Right_Override",
-            BidiClass::NonspacingMark => "Nonspacing_Mark",
-            BidiClass::OtherNeutral => "Other_Neutral",
-            BidiClass::PopDirectionalFormat => "Pop_Directional_Format",
-            BidiClass::PopDirectionalIsolate => "Pop_Directional_Isolate",
-            BidiClass::RightToLeft => "Right_To_Left",
-            BidiClass::RightToLeftEmbedding => "Right_To_Left_Embedding",
-            BidiClass::RightToLeftIsolate => "Right_To_Left_Isolate",
-            BidiClass::RightToLeftOverride => "Right_To_Left_Override",
-            BidiClass::SegmentSeparator => "Segment_Separator",
-            BidiClass::WhiteSpace => "White_Space",
-        }
-    }
-
-    /// The *human-readable name* of the property value.
-    #[inline]
-    pub fn human_name(&self) -> &'static str {
-        match *self {
-            // Strong
-            BidiClass::LeftToRight => "Left-to-Right",
-            BidiClass::RightToLeft => "Right-to-Left",
-            BidiClass::ArabicLetter => "Right-to-Left Arabic",
-
-            // Weak
-            BidiClass::EuropeanNumber => "European Number",
-            BidiClass::EuropeanSeparator => "European Number Separator",
-            BidiClass::EuropeanTerminator => "European Number Terminator",
-            BidiClass::ArabicNumber => "Arabic Number",
-            BidiClass::CommonSeparator => "Common Number Separator",
-            BidiClass::NonspacingMark => "Nonspacing Mark",
-            BidiClass::BoundaryNeutral => "Boundary Neutral",
-
-            // Neutral
-            BidiClass::ParagraphSeparator => "Paragraph Separator",
-            BidiClass::SegmentSeparator => "Segment Separator",
-            BidiClass::WhiteSpace => "Whitespace",
-            BidiClass::OtherNeutral => "Other Neutrals",
-
-            // Explicit Formatting
-            BidiClass::LeftToRightEmbedding => "Left-to-Right Embedding",
-            BidiClass::LeftToRightOverride => "Left-to-Right Override",
-            BidiClass::RightToLeftEmbedding => "Right-to-Left Embedding",
-            BidiClass::RightToLeftOverride => "Right-to-Left Override",
-            BidiClass::PopDirectionalFormat => "Pop Directional Format",
-            BidiClass::LeftToRightIsolate => "Left-to-Right Isolate",
-            BidiClass::RightToLeftIsolate => "Right-to-Left Isolate",
-            BidiClass::FirstStrongIsolate => "First Strong Isolate",
-            BidiClass::PopDirectionalIsolate => "Pop Directional Isolate",
-        }
+        *BIDI_CLASS_TABLE.find_or(ch, &Default::default())
     }
 
     /// If the `BidiClass` has strong or explicit Left-to-Right direction.
@@ -314,22 +287,9 @@ impl BidiClass {
 }
 
 
-impl Default for BidiClass {
-    fn default() -> Self {
-        BidiClass::LeftToRight
-    }
-}
-
-
-impl fmt::Display for BidiClass {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.human_name())
-    }
-}
-
-
 #[cfg(test)]
 mod tests {
+    use unic_char_property::EnumeratedCharProperty;
     use super::BidiClass;
     use super::abbr_names::*;
 

--- a/unic/ucd/bidi/src/lib.rs
+++ b/unic/ucd/bidi/src/lib.rs
@@ -19,6 +19,7 @@
 //!
 //! Accessor for `Bidi_Class` property from Unicode Character Database (UCD)
 
+#[macro_use]
 extern crate unic_char_property;
 extern crate unic_ucd_core;
 extern crate unic_utils;

--- a/unic/ucd/category/src/category.rs
+++ b/unic/ucd/category/src/category.rs
@@ -9,95 +9,234 @@
 // except according to those terms.
 
 
-use std::fmt;
-
 use unic_utils::CharDataTable;
-use unic_char_property::{CharProperty, CompleteCharProperty, EnumeratedCharProperty};
+use unic_char_property::CompleteCharProperty;
 
+char_property! {
+    /// Represents the Unicode Character
+    /// [*General_Category*](http://unicode.org/reports/tr44/#General_Category) property.
+    ///
+    /// This is a useful breakdown into various character types which can be used as a default
+    /// categorization in implementations. For the property values, see
+    /// [*General_Category Values*](http://unicode.org/reports/tr44/#General_Category_Values).
+    pub enum GeneralCategory {
+        abbr => "gc";
+        long => "General_Category";
+        human => "General Category";
 
-/// Represents the Unicode Character
-/// [*General_Category*](http://unicode.org/reports/tr44/#General_Category) property.
-///
-/// This is a useful breakdown into various character types which can be used as a default
-/// categorization in implementations. For the property values, see
-/// [*General_Category Values*](http://unicode.org/reports/tr44/#General_Category_Values).
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum GeneralCategory {
-    /// An uppercase letter (Short form: `Lu`)
-    UppercaseLetter,
-    /// A lowercase letter (Short form: `Ll`)
-    LowercaseLetter,
-    /// A digraphic character, with first part uppercase (Short form: `Lt`)
-    TitlecaseLetter,
-    /// A modifier letter (Short form: `Lm`)
-    ModifierLetter,
-    /// Other letters, including syllables and ideographs (Short form: `Lo`)
-    OtherLetter,
-    /// A nonspacing combining mark (zero advance width) (Short form: `Mn`)
-    NonspacingMark,
-    /// A spacing combining mark (positive advance width) (Short form: `Mc`)
-    SpacingMark,
-    /// An enclosing combining mark (Short form: `Me`)
-    EnclosingMark,
-    /// A decimal digit (Short form: `Nd`)
-    DecimalNumber,
-    /// A letterlike numeric character (Short form: `Nl`)
-    LetterNumber,
-    /// A numeric character of other type (Short form: `No`)
-    OtherNumber,
-    /// A connecting punctuation mark, like a tie (Short form: `Pc`)
-    ConnectorPunctuation,
-    /// A dash or hyphen punctuation mark (Short form: `Pd`)
-    DashPunctuation,
-    /// An opening punctuation mark (of a pair) (Short form: `Ps`)
-    OpenPunctuation,
-    /// A closing punctuation mark (of a pair) (Short form: `Pe`)
-    ClosePunctuation,
-    /// An initial quotation mark (Short form: `Pi`)
-    InitialPunctuation,
-    /// A final quotation mark (Short form: `Pf`)
-    FinalPunctuation,
-    /// A punctuation mark of other type (Short form: `Po`)
-    OtherPunctuation,
-    /// A symbol of mathematical use (Short form: `Sm`)
-    MathSymbol,
-    /// A currency sign (Short form: `Sc`)
-    CurrencySymbol,
-    /// A non-letterlike modifier symbol (Short form: `Sk`)
-    ModifierSymbol,
-    /// A symbol of other type (Short form: `So`)
-    OtherSymbol,
-    /// A space character (of various non-zero widths) (Short form: `Zs`)
-    SpaceSeparator,
-    /// U+2028 LINE SEPARATOR only (Short form: `Zl`)
-    LineSeparator,
-    /// U+2029 PARAGRAPH SEPARATOR only (Short form: `Zp`)
-    ParagraphSeparator,
-    /// A C0 or C1 control code (Short form: `Cc`)
-    Control,
-    /// A format control character (Short form: `Cf`)
-    Format,
-    /// A surrogate code point (Short form: `Cs`)
-    Surrogate,
-    /// A private-use character (Short form: `Co`)
-    PrivateUse,
-    /// Unassigned (Short form: `Cn`)
-    Unassigned,
-}
+        /// An uppercase letter
+        UppercaseLetter {
+            abbr => Lu,
+            long => Uppercase_Letter,
+            human => "Uppercase Letter",
+        }
 
+        /// A lowercase letter
+        LowercaseLetter {
+            abbr => Ll,
+            long => Lowercase_Letter,
+            human => "Lowercase Letter",
+        }
 
-impl CharProperty for GeneralCategory {
-    fn prop_abbr_name() -> &'static str {
-        "gc"
+        /// A digraphic character, with first part uppercase
+        TitlecaseLetter {
+            abbr => Lt,
+            long => Titlecase_Letter,
+            human => "Titlecase Letter",
+        }
+
+        /// A modifier letter
+        ModifierLetter {
+            abbr => Lm,
+            long => Modifier_Letter,
+            human => "Modifier Letter",
+        }
+
+        /// Other letters, including syllables and ideographs
+        OtherLetter {
+            abbr => Lo,
+            long => Other_Letter,
+            human => "Other Letter",
+        }
+
+        /// A nonspacing combining mark (zero advance width)
+        NonspacingMark {
+            abbr => Mn,
+            long => Nonspacing_Mark,
+            human => "Nonspacing Mark",
+        }
+
+        /// A spacing combining mark (positive advance width)
+        SpacingMark {
+            abbr => Mc,
+            long => Spacing_Mark,
+            human => "Spacing Mark",
+        }
+
+        /// An enclosing combining mark
+        EnclosingMark {
+            abbr => Me,
+            long => Enclosing_Mark,
+            human => "Enclosing Mark",
+        }
+
+        /// A decimal digit
+        DecimalNumber {
+            abbr => Nd,
+            long => Decimal_Number,
+            human => "Decimal Digit",
+        }
+
+        /// A letterlike numeric character
+        LetterNumber {
+            abbr => Nl,
+            long => Letter_Number,
+            human => "Letterlike Number",
+        }
+
+        /// A numeric character of other type
+        OtherNumber {
+            abbr => No,
+            long => Other_Number,
+            human => "Other Numeric",
+        }
+
+        /// A connecting punctuation mark, like a tie
+        ConnectorPunctuation {
+            abbr => Pc,
+            long => Connector_Punctuation,
+            human => "Connecting Punctuation",
+        }
+
+        /// A dash or hyphen punctuation mark
+        DashPunctuation {
+            abbr => Pd,
+            long => Dash_Punctuation,
+            human => "Dash Punctuation",
+        }
+
+        /// An opening punctuation mark (of a pair)
+        OpenPunctuation {
+            abbr => Ps,
+            long => Open_Punctuation,
+            human => "Opening Punctuation",
+        }
+
+        /// A closing punctuation mark (of a pair)
+        ClosePunctuation {
+            abbr => Pe,
+            long => Close_Punctuation,
+            human => "Closing Punctuation",
+        }
+
+        /// An initial quotation mark
+        InitialPunctuation {
+            abbr => Pi,
+            long => Initial_Punctuation,
+            human => "Initial Quotation",
+        }
+
+        /// A final quotation mark
+        FinalPunctuation {
+            abbr => Pf,
+            long => Final_Punctuation,
+            human => "Final Quotation",
+        }
+
+        /// A punctuation mark of other type
+        OtherPunctuation {
+            abbr => Po,
+            long => Other_Punctuation,
+            human => "Other Punctuation",
+        }
+
+        /// A symbol of mathematical use
+        MathSymbol {
+            abbr => Sm,
+            long => Math_Symbol,
+            human => "Math Symbol",
+        }
+
+        /// A currency sign
+        CurrencySymbol {
+            abbr => Sc,
+            long => Currency_Symbol,
+            human => "Currency Symbol",
+        }
+
+        /// A non-letterlike modifier symbol
+        ModifierSymbol {
+            abbr => Sk,
+            long => Modifier_Symbol,
+            human => "Modifier Symbol",
+        }
+
+        /// A symbol of other type
+        OtherSymbol {
+            abbr => So,
+            long => Other_Symbol,
+            human => "Other Symbol",
+        }
+
+        /// A space character (of various non-zero widths)
+        SpaceSeparator {
+            abbr => Zs,
+            long => Space_Separator,
+            human => "Space",
+        }
+
+        /// U+2028 LINE SEPARATOR only
+        LineSeparator {
+            abbr => Zl,
+            long => Line_Separator,
+            human => "Line Separator",
+        }
+
+        /// U+2029 PARAGRAPH SEPARATOR only
+        ParagraphSeparator {
+            abbr => Zp,
+            long => Paragraph_Separator,
+            human => "Paragraph Separator",
+        }
+
+        /// A C0 or C1 control code
+        Control {
+            abbr => Cc,
+            long => Control,
+            human => "Control",
+        }
+
+        /// A format control character
+        Format {
+            abbr => Cf,
+            long => Format,
+            human => "Formatting",
+        }
+
+        /// A surrogate code point
+        Surrogate {
+            abbr => Cs,
+            long => Surrogate,
+            human => "Surrogate",
+        }
+
+        /// A private-use character
+        PrivateUse {
+            abbr => Co,
+            long => Private_Use,
+            human => "Private-Use",
+        }
+
+        /// Unassigned
+        Unassigned {
+            abbr => Cn,
+            long => Unassigned,
+            human => "Unassigned",
+        }
     }
 
-    fn prop_long_name() -> &'static str {
-        "General_Category"
-    }
-
-    fn prop_human_name() -> &'static str {
-        "General Category"
-    }
+    pub mod abbr_names for abbr;
+    pub mod long_names for long;
 }
 
 
@@ -108,212 +247,23 @@ impl CompleteCharProperty for GeneralCategory {
 }
 
 
-impl EnumeratedCharProperty for GeneralCategory {
-    fn all_values() -> &'static [Self] {
-        Self::all_values()
-    }
-
-    fn abbr_name(&self) -> &'static str {
-        self.abbr_name()
-    }
-
-    fn long_name(&self) -> &'static str {
-        self.long_name()
-    }
-
-    fn human_name(&self) -> &'static str {
-        self.human_name()
+impl Default for GeneralCategory {
+    fn default() -> Self {
+        GeneralCategory::Unassigned
     }
 }
 
 
-pub mod abbr_names {
-    pub use GeneralCategory::UppercaseLetter as Lu;
-    pub use GeneralCategory::LowercaseLetter as Ll;
-    pub use GeneralCategory::TitlecaseLetter as Lt;
-    pub use GeneralCategory::ModifierLetter as Lm;
-    pub use GeneralCategory::OtherLetter as Lo;
-    pub use GeneralCategory::NonspacingMark as Mn;
-    pub use GeneralCategory::SpacingMark as Mc;
-    pub use GeneralCategory::EnclosingMark as Me;
-    pub use GeneralCategory::DecimalNumber as Nd;
-    pub use GeneralCategory::LetterNumber as Nl;
-    pub use GeneralCategory::OtherNumber as No;
-    pub use GeneralCategory::ConnectorPunctuation as Pc;
-    pub use GeneralCategory::DashPunctuation as Pd;
-    pub use GeneralCategory::OpenPunctuation as Ps;
-    pub use GeneralCategory::ClosePunctuation as Pe;
-    pub use GeneralCategory::InitialPunctuation as Pi;
-    pub use GeneralCategory::FinalPunctuation as Pf;
-    pub use GeneralCategory::OtherPunctuation as Po;
-    pub use GeneralCategory::MathSymbol as Sm;
-    pub use GeneralCategory::CurrencySymbol as Sc;
-    pub use GeneralCategory::ModifierSymbol as Sk;
-    pub use GeneralCategory::OtherSymbol as So;
-    pub use GeneralCategory::SpaceSeparator as Zs;
-    pub use GeneralCategory::LineSeparator as Zl;
-    pub use GeneralCategory::ParagraphSeparator as Zp;
-    pub use GeneralCategory::Control as Cc;
-    pub use GeneralCategory::Format as Cf;
-    pub use GeneralCategory::Surrogate as Cs;
-    pub use GeneralCategory::PrivateUse as Co;
-    pub use GeneralCategory::Unassigned as Cn;
-}
 use self::abbr_names::*;
 
 const GENERAL_CATEGORY_TABLE: &'static [(char, char, GeneralCategory)] =
     include!("tables/general_category.rsv");
 
+
 impl GeneralCategory {
     /// Find the `GeneralCategory` of a single char.
     pub fn of(ch: char) -> GeneralCategory {
         *GENERAL_CATEGORY_TABLE.find_or(ch, &GeneralCategory::Unassigned)
-    }
-
-    /// Exhaustive list of all `GeneralCategory` property values.
-    pub fn all_values() -> &'static [GeneralCategory] {
-        const ALL_VALUES: &[GeneralCategory] = &[
-            GeneralCategory::UppercaseLetter,
-            GeneralCategory::LowercaseLetter,
-            GeneralCategory::TitlecaseLetter,
-            GeneralCategory::ModifierLetter,
-            GeneralCategory::OtherLetter,
-            GeneralCategory::NonspacingMark,
-            GeneralCategory::SpacingMark,
-            GeneralCategory::EnclosingMark,
-            GeneralCategory::DecimalNumber,
-            GeneralCategory::LetterNumber,
-            GeneralCategory::OtherNumber,
-            GeneralCategory::ConnectorPunctuation,
-            GeneralCategory::DashPunctuation,
-            GeneralCategory::OpenPunctuation,
-            GeneralCategory::ClosePunctuation,
-            GeneralCategory::InitialPunctuation,
-            GeneralCategory::FinalPunctuation,
-            GeneralCategory::OtherPunctuation,
-            GeneralCategory::MathSymbol,
-            GeneralCategory::CurrencySymbol,
-            GeneralCategory::ModifierSymbol,
-            GeneralCategory::OtherSymbol,
-            GeneralCategory::SpaceSeparator,
-            GeneralCategory::LineSeparator,
-            GeneralCategory::ParagraphSeparator,
-            GeneralCategory::Control,
-            GeneralCategory::Format,
-            GeneralCategory::Surrogate,
-            GeneralCategory::PrivateUse,
-            GeneralCategory::Unassigned,
-        ];
-        ALL_VALUES
-    }
-
-    /// The *abbreviated name* of the property value.
-    pub fn abbr_name(&self) -> &'static str {
-        match *self {
-            GeneralCategory::UppercaseLetter => "Lu",
-            GeneralCategory::LowercaseLetter => "Ll",
-            GeneralCategory::TitlecaseLetter => "Lt",
-            GeneralCategory::ModifierLetter => "Lm",
-            GeneralCategory::OtherLetter => "Lo",
-            GeneralCategory::NonspacingMark => "Mn",
-            GeneralCategory::SpacingMark => "Mc",
-            GeneralCategory::EnclosingMark => "Me",
-            GeneralCategory::DecimalNumber => "Nd",
-            GeneralCategory::LetterNumber => "Nl",
-            GeneralCategory::OtherNumber => "No",
-            GeneralCategory::ConnectorPunctuation => "Pc",
-            GeneralCategory::DashPunctuation => "Pd",
-            GeneralCategory::OpenPunctuation => "Ps",
-            GeneralCategory::ClosePunctuation => "Pe",
-            GeneralCategory::InitialPunctuation => "Pi",
-            GeneralCategory::FinalPunctuation => "Pf",
-            GeneralCategory::OtherPunctuation => "Po",
-            GeneralCategory::MathSymbol => "Sm",
-            GeneralCategory::CurrencySymbol => "Sc",
-            GeneralCategory::ModifierSymbol => "Sk",
-            GeneralCategory::OtherSymbol => "So",
-            GeneralCategory::SpaceSeparator => "Zs",
-            GeneralCategory::LineSeparator => "Zl",
-            GeneralCategory::ParagraphSeparator => "Zp",
-            GeneralCategory::Control => "Cc",
-            GeneralCategory::Format => "Cf",
-            GeneralCategory::Surrogate => "Cs",
-            GeneralCategory::PrivateUse => "Co",
-            GeneralCategory::Unassigned => "Cn",
-        }
-    }
-
-    /// The *long name* of the property value.
-    pub fn long_name(&self) -> &'static str {
-        match *self {
-            GeneralCategory::UppercaseLetter => "Uppercase_Letter",
-            GeneralCategory::LowercaseLetter => "Lowercase_Letter",
-            GeneralCategory::TitlecaseLetter => "Titlecase_Letter",
-            GeneralCategory::ModifierLetter => "Modifier_Letter",
-            GeneralCategory::OtherLetter => "Other_Letter",
-            GeneralCategory::NonspacingMark => "Nonspacing_Mark",
-            GeneralCategory::SpacingMark => "Spacing_Mark",
-            GeneralCategory::EnclosingMark => "Enclosing_Mark",
-            GeneralCategory::DecimalNumber => "Decimal_Number",
-            GeneralCategory::LetterNumber => "Letter_Number",
-            GeneralCategory::OtherNumber => "Other_Number",
-            GeneralCategory::ConnectorPunctuation => "Connector_Punctuation",
-            GeneralCategory::DashPunctuation => "Dash_Punctuation",
-            GeneralCategory::OpenPunctuation => "Open_Punctuation",
-            GeneralCategory::ClosePunctuation => "Close_Punctuation",
-            GeneralCategory::InitialPunctuation => "Initial_Punctuation",
-            GeneralCategory::FinalPunctuation => "Final_Punctuation",
-            GeneralCategory::OtherPunctuation => "Other_Punctuation",
-            GeneralCategory::MathSymbol => "Math_Symbol",
-            GeneralCategory::CurrencySymbol => "Currency_Symbol",
-            GeneralCategory::ModifierSymbol => "Modifier_Symbol",
-            GeneralCategory::OtherSymbol => "Other_Symbol",
-            GeneralCategory::SpaceSeparator => "Space_Separator",
-            GeneralCategory::LineSeparator => "Line_Separator",
-            GeneralCategory::ParagraphSeparator => "Paragraph_Separator",
-            GeneralCategory::Control => "Control",
-            GeneralCategory::Format => "Format",
-            GeneralCategory::Surrogate => "Surrogate",
-            GeneralCategory::PrivateUse => "Private_Use",
-            GeneralCategory::Unassigned => "Unassigned",
-        }
-    }
-
-    /// The *human-readable name* of the property value.
-    #[inline]
-    pub fn human_name(&self) -> &'static str {
-        match *self {
-            GeneralCategory::UppercaseLetter => "Uppercase Letter",
-            GeneralCategory::LowercaseLetter => "Lowercase Letter",
-            GeneralCategory::TitlecaseLetter => "Titlecase Letter",
-            GeneralCategory::ModifierLetter => "Modifier Letter",
-            GeneralCategory::OtherLetter => "Other Letter",
-            GeneralCategory::NonspacingMark => "Nonspacing Mark",
-            GeneralCategory::SpacingMark => "Spacing Mark",
-            GeneralCategory::EnclosingMark => "Enclosing Mark",
-            GeneralCategory::DecimalNumber => "Decimal Number",
-            GeneralCategory::LetterNumber => "Letter Number",
-            GeneralCategory::OtherNumber => "Other Number",
-            GeneralCategory::ConnectorPunctuation => "Connector Punctuation",
-            GeneralCategory::DashPunctuation => "Dash Punctuation",
-            GeneralCategory::OpenPunctuation => "Open Punctuation",
-            GeneralCategory::ClosePunctuation => "Close Punctuation",
-            GeneralCategory::InitialPunctuation => "Initial Punctuation",
-            GeneralCategory::FinalPunctuation => "Final Punctuation",
-            GeneralCategory::OtherPunctuation => "Other Punctuation",
-            GeneralCategory::MathSymbol => "Math Symbol",
-            GeneralCategory::CurrencySymbol => "Currency Symbol",
-            GeneralCategory::ModifierSymbol => "Modifier Symbol",
-            GeneralCategory::OtherSymbol => "Other Symbol",
-            GeneralCategory::SpaceSeparator => "Space Separator",
-            GeneralCategory::LineSeparator => "Line Separator",
-            GeneralCategory::ParagraphSeparator => "Paragraph Separator",
-            GeneralCategory::Control => "Control",
-            GeneralCategory::Format => "Format",
-            GeneralCategory::Surrogate => "Surrogate",
-            GeneralCategory::PrivateUse => "Private Use",
-            GeneralCategory::Unassigned => "Unassigned",
-        }
     }
 }
 
@@ -361,22 +311,9 @@ impl GeneralCategory {
 }
 
 
-impl Default for GeneralCategory {
-    fn default() -> Self {
-        GeneralCategory::Unassigned
-    }
-}
-
-
-impl fmt::Display for GeneralCategory {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.human_name())
-    }
-}
-
-
 #[cfg(test)]
 mod tests {
+    use unic_char_property::EnumeratedCharProperty;
     use super::GeneralCategory as GC;
     use std::char;
 
@@ -443,7 +380,7 @@ mod tests {
     #[test]
     fn test_bmp_edge() {
         // 0xFEFF ZERO WIDTH NO-BREAK SPACE (or) BYTE ORDER MARK
-        let bom = char::from_u32(0xFEFF).unwrap();
+        let bom = '\u{FEFF}';
         assert_eq!(GC::of(bom), GC::Format);
         // 0xFFFC OBJECT REPLACEMENT CHARACTER
         assert_eq!(GC::of('￼'), GC::OtherSymbol);

--- a/unic/ucd/category/src/lib.rs
+++ b/unic/ucd/category/src/lib.rs
@@ -39,6 +39,7 @@
 #[macro_use]
 extern crate matches;
 
+#[macro_use]
 extern crate unic_char_property;
 extern crate unic_ucd_core;
 extern crate unic_utils;

--- a/unic/ucd/category/tests/major_category_tests.rs
+++ b/unic/ucd/category/tests/major_category_tests.rs
@@ -9,9 +9,11 @@
 // except according to those terms.
 
 
+extern crate unic_char_property;
 extern crate unic_ucd_category;
 
 
+use unic_char_property::EnumeratedCharProperty;
 use unic_ucd_category::GeneralCategory;
 
 

--- a/unic/ucd/normal/src/composition.rs
+++ b/unic/ucd/normal/src/composition.rs
@@ -33,7 +33,7 @@ pub fn canonical_decomposition(c: char) -> Option<&'static [char]> {
 }
 
 // == Compatibility Decomposition (KD) ==
-use DecompositionType::*;
+use decomposition_type::long_names::*;
 pub const COMPATIBILITY_DECOMPOSITION_MAPPING: &'static [(
     char,
     (DecompositionType, &'static [char]),

--- a/unic/ucd/normal/src/decomposition_type.rs
+++ b/unic/ucd/normal/src/decomposition_type.rs
@@ -12,55 +12,155 @@
 
 //! Accessor for *Decomposition_Type* (dt) property
 
-use std::fmt;
-
 use unic_utils::CharDataTable;
-use unic_char_property::{CharProperty, EnumeratedCharProperty, PartialCharProperty};
+use unic_char_property::PartialCharProperty;
 
 use composition::{canonical_decomposition, COMPATIBILITY_DECOMPOSITION_MAPPING};
 use hangul;
 
+char_property! {
+    /// Represents the Unicode character
+    /// [*Decomposition_Type*](http://www.unicode.org/reports/tr44/#Decomposition_Type) property.
+    ///
+    /// * <http://www.unicode.org/reports/tr44/#Character_Decomposition_Mappings>
+    pub enum DecompositionType {
+        abbr => "dt";
+        long => "Decomposition_Type";
+        human => "Decomposition Type";
 
-/// Represents the Unicode character
-/// [*Decomposition_Type*](http://www.unicode.org/reports/tr44/#Decomposition_Type) property.
-///
-/// * <http://www.unicode.org/reports/tr44/#Character_Decomposition_Mappings>
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[allow(missing_docs)]
-pub enum DecompositionType {
-    Canonical,
-    Compat,
-    Circle,
-    Final,
-    Font,
-    Fraction,
-    Initial,
-    Isolated,
-    Medial,
-    Narrow,
-    Nobreak,
-    None,
-    Small,
-    Square,
-    Sub,
-    Super,
-    Vertical,
-    Wide,
-}
+        #[allow(missing_docs)]
+        Canonical {
+            abbr => Can,
+            long => Canonical,
+            human => "Canonical",
+        }
 
+        /// Otherwise unspecified compatibility character
+        Compat {
+            abbr => Com,
+            long => Compat,
+            human => "Unspecified",
+        }
 
-impl CharProperty for DecompositionType {
-    fn prop_abbr_name() -> &'static str {
-        "dt"
+        /// Encircled form
+        Circle {
+            abbr => Enc,
+            long => Circle,
+            human => "Encircled",
+        }
+
+        /// Final presentation form (Arabic)
+        Final {
+            abbr => Fin,
+            long => Final,
+            human => "Arabic Final",
+        }
+
+        /// Font variant (for example, a blackletter form)
+        Font {
+            abbr => Font,
+            long => Font,
+            human => "Font Variant",
+        }
+
+        /// Vulgar fraction form
+        Fraction {
+            abbr => Fra,
+            long => Fraction,
+            human => "Vulgar Fraction",
+        }
+
+        /// Initial presentation form (Arabic)
+        Initial {
+            abbr => Init,
+            long => Initial,
+            human => "Arabic Initial",
+        }
+
+        /// Isolated presentation form (Arabic)
+        Isolated {
+            abbr => Iso,
+            long => Isolated,
+            human => "Arabic Isolated",
+        }
+
+        /// Medial presentation form (Arabic)
+        Medial {
+            abbr => Med,
+            long => Medial,
+            human => "Arabic Medial",
+        }
+
+        /// Narrow (or hankaku) compatibility character
+        Narrow {
+            abbr => Nar,
+            long => Narrow,
+            human => "Narrow",
+        }
+
+        /// No-break version of a space or hyphen
+        NoBreak {
+            abbr => Nb,
+            long => Nobreak,
+            human => "No-Break",
+        }
+
+        // TODO: Is this used?
+        #[allow(missing_docs)]
+        None {
+            abbr => None,
+            long => None,
+            human => "None",
+        }
+
+        /// Small variant form (CNS compatibility)
+        Small {
+            abbr => Sml,
+            long => Small,
+            human => "Small",
+        }
+
+        /// CJK squared font variant
+        Square {
+            abbr => Sqr,
+            long => Square,
+            human => "Squared",
+        }
+
+        /// Subscript form
+        Sub {
+            abbr => Sub,
+            long => Sub,
+            human => "Subscript",
+        }
+
+        /// Superscript form
+        Super {
+            abbr => Sup,
+            long => Super,
+            human => "Superscript",
+        }
+
+        /// Vertical layout presentation form
+        Vertical {
+            abbr => Vert,
+            long => Vertical,
+            human => "Vertical Layout",
+        }
+
+        /// Wide (or zenkaku) compatibility character
+        Wide {
+            abbr => Wide,
+            long => Wide,
+            human => "Wide",
+        }
     }
 
-    fn prop_long_name() -> &'static str {
-        "Decomposition_Type"
-    }
+    #[allow(missing_docs)]
+    pub mod abbr_names for abbr;
 
-    fn prop_human_name() -> &'static str {
-        "Decomposition Type"
-    }
+    #[allow(missing_docs)]
+    pub mod long_names for long;
 }
 
 
@@ -71,169 +171,21 @@ impl PartialCharProperty for DecompositionType {
 }
 
 
-impl EnumeratedCharProperty for DecompositionType {
-    fn all_values() -> &'static [Self] {
-        Self::all_values()
-    }
-
-    fn abbr_name(&self) -> &'static str {
-        self.abbr_name()
-    }
-
-    fn long_name(&self) -> &'static str {
-        self.long_name()
-    }
-
-    fn human_name(&self) -> &'static str {
-        self.human_name()
-    }
-}
-
-
-pub mod abbr_names {
-    pub use DecompositionType::Canonical as Can;
-    pub use DecompositionType::Compat as Com;
-    pub use DecompositionType::Circle as Enc;
-    pub use DecompositionType::Final as Fin;
-    pub use DecompositionType::Font;
-    pub use DecompositionType::Fraction as Fra;
-    pub use DecompositionType::Initial as Init;
-    pub use DecompositionType::Isolated as Iso;
-    pub use DecompositionType::Medial as Med;
-    pub use DecompositionType::Narrow as Nar;
-    pub use DecompositionType::Nobreak as Nb;
-    pub use DecompositionType::None;
-    pub use DecompositionType::Small as Sml;
-    pub use DecompositionType::Square as Sqr;
-    pub use DecompositionType::Sub;
-    pub use DecompositionType::Super as Sup;
-    pub use DecompositionType::Vertical as Vert;
-    pub use DecompositionType::Wide;
-}
-
-
-use self::DecompositionType::*;
-
-
 impl DecompositionType {
     /// Find the DecompositionType of a single char.
     pub fn of(ch: char) -> Option<DecompositionType> {
         // First, check for Hangul Syllables and other canonical decompositions
         if hangul::is_syllable(ch) || canonical_decomposition(ch).is_some() {
-            return Some(Canonical);
+            return Some(DecompositionType::Canonical);
         }
         COMPATIBILITY_DECOMPOSITION_MAPPING.find(ch).map(|it| it.0)
-    }
-
-    /// Exhaustive list of all `DecompositionType` property values.
-    pub fn all_values() -> &'static [DecompositionType] {
-        use DecompositionType::*;
-        const ALL_VALUES: &[DecompositionType] = &[
-            Canonical,
-            Compat,
-            Circle,
-            Final,
-            Font,
-            Fraction,
-            Initial,
-            Isolated,
-            Medial,
-            Narrow,
-            Nobreak,
-            None,
-            Small,
-            Square,
-            Sub,
-            Super,
-            Vertical,
-            Wide,
-        ];
-        ALL_VALUES
-    }
-
-    /// The *abbreviated name* of the property value.
-    pub fn abbr_name(&self) -> &'static str {
-        match *self {
-            DecompositionType::Canonical => "Can",
-            DecompositionType::Compat => "Com",
-            DecompositionType::Circle => "Enc",
-            DecompositionType::Final => "Fin",
-            DecompositionType::Font => "Font",
-            DecompositionType::Fraction => "Fra",
-            DecompositionType::Initial => "Init",
-            DecompositionType::Isolated => "Iso",
-            DecompositionType::Medial => "Med",
-            DecompositionType::Narrow => "Nar",
-            DecompositionType::Nobreak => "Nb",
-            DecompositionType::None => "None",
-            DecompositionType::Small => "Sml",
-            DecompositionType::Square => "Sqr",
-            DecompositionType::Sub => "Sub",
-            DecompositionType::Super => "Sup",
-            DecompositionType::Vertical => "Vert",
-            DecompositionType::Wide => "Wide",
-        }
-    }
-
-    /// The *long name* of the property value.
-    pub fn long_name(&self) -> &'static str {
-        match *self {
-            DecompositionType::Canonical => "Canonical",
-            DecompositionType::Compat => "Compat",
-            DecompositionType::Circle => "Circle",
-            DecompositionType::Final => "Final",
-            DecompositionType::Font => "Font",
-            DecompositionType::Fraction => "Fraction",
-            DecompositionType::Initial => "Initial",
-            DecompositionType::Isolated => "Isolated",
-            DecompositionType::Medial => "Medial",
-            DecompositionType::Narrow => "Narrow",
-            DecompositionType::Nobreak => "Nobreak",
-            DecompositionType::None => "None",
-            DecompositionType::Small => "Small",
-            DecompositionType::Square => "Square",
-            DecompositionType::Sub => "Sub",
-            DecompositionType::Super => "Super",
-            DecompositionType::Vertical => "Vertical",
-            DecompositionType::Wide => "Wide",
-        }
-    }
-
-    /// The *human-readable name* of the property value.
-    pub fn human_name(&self) -> &'static str {
-        match *self {
-            DecompositionType::Canonical => "Canonical",
-            DecompositionType::Compat => "Compat",
-            DecompositionType::Circle => "Circle",
-            DecompositionType::Final => "Final",
-            DecompositionType::Font => "Font",
-            DecompositionType::Fraction => "Fraction",
-            DecompositionType::Initial => "Initial",
-            DecompositionType::Isolated => "Isolated",
-            DecompositionType::Medial => "Medial",
-            DecompositionType::Narrow => "Narrow",
-            DecompositionType::Nobreak => "No-Break",
-            DecompositionType::None => "None",
-            DecompositionType::Small => "Small",
-            DecompositionType::Square => "Square",
-            DecompositionType::Sub => "Sub",
-            DecompositionType::Super => "Super",
-            DecompositionType::Vertical => "Vertical",
-            DecompositionType::Wide => "Wide",
-        }
-    }
-}
-
-
-impl fmt::Display for DecompositionType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.human_name())
     }
 }
 
 
 #[cfg(test)]
 mod tests {
+    use unic_char_property::EnumeratedCharProperty;
     use super::DecompositionType as DT;
 
     #[test]
@@ -248,7 +200,7 @@ mod tests {
     #[test]
     fn test_bmp() {
         // Compatibility
-        assert_eq!(DT::of('\u{a0}'), Some(DT::Nobreak));
+        assert_eq!(DT::of('\u{a0}'), Some(DT::NoBreak));
         assert_eq!(DT::of('\u{a8}'), Some(DT::Compat));
         assert_eq!(DT::of('\u{aa}'), Some(DT::Super));
         assert_eq!(DT::of('\u{af}'), Some(DT::Compat));
@@ -364,19 +316,19 @@ mod tests {
     #[test]
     fn test_abbr_name() {
         assert_eq!(DT::Canonical.abbr_name(), "Can");
-        assert_eq!(DT::Nobreak.abbr_name(), "Nb");
+        assert_eq!(DT::NoBreak.abbr_name(), "Nb");
     }
 
     #[test]
     fn test_long_name() {
         assert_eq!(DT::Canonical.long_name(), "Canonical");
-        assert_eq!(DT::Nobreak.long_name(), "Nobreak");
+        assert_eq!(DT::NoBreak.long_name(), "Nobreak");
     }
 
     #[test]
     fn test_human_name() {
         assert_eq!(DT::Canonical.human_name(), "Canonical");
-        assert_eq!(DT::Nobreak.human_name(), "No-Break");
+        assert_eq!(DT::NoBreak.human_name(), "No-Break");
     }
 
     #[test]

--- a/unic/ucd/normal/src/decomposition_type.rs
+++ b/unic/ucd/normal/src/decomposition_type.rs
@@ -105,14 +105,6 @@ char_property! {
             human => "No-Break",
         }
 
-        // TODO: Is this used?
-        #[allow(missing_docs)]
-        None {
-            abbr => None,
-            long => None,
-            human => "None",
-        }
-
         /// Small variant form (CNS compatibility)
         Small {
             abbr => Sml,
@@ -124,7 +116,7 @@ char_property! {
         Square {
             abbr => Sqr,
             long => Square,
-            human => "Squared",
+            human => "CJK Squared",
         }
 
         /// Subscript form

--- a/unic/ucd/normal/src/lib.rs
+++ b/unic/ucd/normal/src/lib.rs
@@ -28,6 +28,7 @@
 //! }
 //! ```
 
+#[macro_use]
 extern crate unic_char_property;
 extern crate unic_ucd_core;
 extern crate unic_utils;

--- a/unic/ucd/normal/tests/conformance_tests.rs
+++ b/unic/ucd/normal/tests/conformance_tests.rs
@@ -67,7 +67,7 @@ fn test_decomposition_type_conformance() {
                     .unwrap_or(low);
                 low..(high + 1)
             };
-            let exp_dt = Some(get_dt_from_name(fields[1]));
+            let exp_dt = Some(fields[1].parse().expect("Invalid Decomposition Type"));
 
             for codepoint in input_range {
                 // TODO: We should be safe to use from_u32_unsafe
@@ -124,29 +124,5 @@ fn test_decomposition_type_conformance() {
             failures.len() - 1,
             failures[failures.len() - 1],
         );
-    }
-}
-
-fn get_dt_from_name(name: &str) -> DT {
-    match name {
-        "Canonical" | "Can" => DT::Canonical,
-        "Compat" | "Com" => DT::Compat,
-        "Circle" | "Enc" => DT::Circle,
-        "Final" | "Fin" => DT::Final,
-        "Font" => DT::Font,
-        "Fraction" | "Fra" => DT::Fraction,
-        "Initial" | "Init" => DT::Initial,
-        "Isolated" | "Iso" => DT::Isolated,
-        "Medial" | "Med" => DT::Medial,
-        "Narrow" | "Nar" => DT::Narrow,
-        "Nobreak" | "Nb" => DT::Nobreak,
-        "None" => DT::None,
-        "Small" | "Sml" => DT::Small,
-        "Square" | "Sqr" => DT::Square,
-        "Sub" => DT::Sub,
-        "Super" | "Sup" => DT::Super,
-        "Vertical" | "Vert" => DT::Vertical,
-        "Wide" => DT::Wide,
-        &_ => panic!("Invalid Decomposition_Type name: {}", name),
     }
 }


### PR DESCRIPTION
I can submit a separate PR after 31e6582 if we want to pull the edited macro and the application separately.

The diff is kind of opaque because this touches so much. You're probably better off just comparing before/after the PR without looking at the diff output.

This PR is submitted in a ready-to-merge (after review) state rather than my more usual track-final-polish.

This will require a rebase of #118 as it touches many of the same parts of the code.