### PR TITLE
GitHub: Ignore generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/tables/* linguist-generated=true


### PR DESCRIPTION
GitHub thinks the repository is 53.7% RenderScript and 45.5% Rust. Oops!

![RenderScript](http://i.imgur.com/rEwg45a.png)

This just tells GitHub/linguist to ignore any files matching `**/tables/*` as generated code.

Another option is the following .gitattributes:

```gitattributes
*.rs linguist-language=Rust
*.rsv linguist-generated=true
```

<https://github.com/github/linguist#troubleshooting>