### PR TITLE
Replace unnecessary display methods with to_string.

### DIFF
--- a/unic/char/property/src/property.rs
+++ b/unic/char/property/src/property.rs
@@ -12,12 +12,12 @@
 //! Taxonomy and contracts for Character Property types.
 
 
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 use std::hash::Hash;
 
 
 /// A Character Property, defined for some or all Unicode characters.
-pub trait CharProperty: PartialCharProperty + Debug + Display + Eq + Hash {
+pub trait CharProperty: PartialCharProperty + Debug + Eq + Hash {
     /// The *abbreviated name* of the property.
     fn prop_abbr_name() -> &'static str;
 

--- a/unic/ucd/age/src/age.rs
+++ b/unic/ucd/age/src/age.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 
-use std::fmt;
 use std::cmp;
 
 pub use unic_ucd_core::UnicodeVersion;
@@ -89,13 +88,6 @@ impl Age {
     pub fn actual(&self) -> UnicodeVersion {
         self.0
     }
-
-    /// Human-readable description of the Age property value.
-    #[inline]
-    // TODO: Review return type
-    pub fn human(&self) -> String {
-        format!("Assigned in Unicode {}", self.0).to_owned()
-    }
 }
 
 
@@ -106,13 +98,6 @@ impl cmp::PartialOrd for Age {
             cmp::Ordering::Less => Some(cmp::Ordering::Greater),
             cmp::Ordering::Equal => Some(cmp::Ordering::Equal),
         }
-    }
-}
-
-
-impl fmt::Display for Age {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.human())
     }
 }
 
@@ -674,21 +659,6 @@ mod tests {
                 minor: 0,
                 micro: 0,
             }))
-        );
-    }
-
-    #[test]
-    fn test_display() {
-        assert_eq!(
-            format!(
-                "{}",
-                Age(UnicodeVersion {
-                    major: 1,
-                    minor: 2,
-                    micro: 3,
-                })
-            ),
-            "Assigned in Unicode 1.2.3"
         );
     }
 }

--- a/unic/ucd/core/src/lib.rs
+++ b/unic/ucd/core/src/lib.rs
@@ -39,18 +39,9 @@ pub struct UnicodeVersion {
 pub const UNICODE_VERSION: UnicodeVersion = include!("../tables/unicode_version.rsv");
 
 
-impl UnicodeVersion {
-    /// Human-readable description of the Age property value.
-    #[inline]
-    pub fn display(&self) -> String {
-        format!("{}.{}.{}", self.major, self.minor, self.micro)
-    }
-}
-
-
 impl fmt::Display for UnicodeVersion {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.display())
+        write!(f, "{}.{}.{}", self.major, self.minor, self.micro)
     }
 }
 

--- a/unic/ucd/name/src/name.rs
+++ b/unic/ucd/name/src/name.rs
@@ -22,14 +22,26 @@ impl Name {
         data::NAMES.find(ch).map(|pieces| Name { pieces })
     }
 
-    pub fn to_string(&self) -> String {
-        self.pieces.join(" ")
+    /// Length of the name in bytes.
+    pub fn len(&self) -> usize {
+        // start with spaces
+        let mut len = self.pieces.len().saturating_sub(1);
+        for piece in self.pieces {
+            len += piece.len();
+        }
+        len
     }
 }
 
 impl fmt::Display for Name {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.to_string())
+        let (first, rest) = self.pieces.split_first().unwrap();
+        f.write_str(first)?;
+        for piece in rest {
+            f.write_str(" ")?;
+            f.write_str(piece)?;
+        }
+        Ok(())
     }
 }
 

--- a/unic/ucd/normal/src/canonical_combining_class.rs
+++ b/unic/ucd/normal/src/canonical_combining_class.rs
@@ -127,18 +127,11 @@ impl CanonicalCombiningClass {
     pub fn of(ch: char) -> CanonicalCombiningClass {
         data::CANONICAL_COMBINING_CLASS_VALUES.find_or_default(ch)
     }
-
-    /// Human-readable description of the property value.
-    // TODO: Needs to be improved by returning long-name with underscores replaced by space.
-    #[inline]
-    pub fn display(&self) -> String {
-        format!("{}", self.number())
-    }
 }
 
 impl fmt::Display for CanonicalCombiningClass {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.display())
+        write!(f, "{}", self.number())
     }
 }
 


### PR DESCRIPTION
The former implementation adds an unnecessary allocation to the `Display` impl. Because implementing `Display` gives the `to_string` method for free, there shouldn't be any `Display` methods.

If there are any methods which offer strings that differ from the `Display` implementation, those should have different names. I deprecated the methods instead of removing them, just to be safe.