### PR TITLE
[ucd/normal/hangul] Use from_u32_unchecked

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,11 @@ script:
   - cargo test  --verbose --all
   - cargo test  --verbose --all --features serde
 
+  #  unic-ucd-normal is used in unic-ucd with non-default feature
+  - cargo test  --verbose --manifest-path unic/ucd/normal/Cargo.toml
+
+  # == Nightly-only ==
+
   - test "$TRAVIS_RUST_VERSION" != "nightly" ||
     cargo test  --verbose --all --all-features
 

--- a/unic/ucd/normal/tests/general_category_tests.rs
+++ b/unic/ucd/normal/tests/general_category_tests.rs
@@ -13,12 +13,12 @@
 #![cfg(not(feature = "unic-ucd-category"))]
 
 
+#[macro_use]
 extern crate unic_char_range;
+
 extern crate unic_ucd_category;
 extern crate unic_ucd_normal;
 
-
-use unic_char_range::CharRange;
 
 use self::unic_ucd_category::GeneralCategory as GC;
 use self::unic_ucd_normal::is_combining_mark;


### PR DESCRIPTION
Replace `mem::transmute()` with `char::from_u32_unchecked()`, as its
more clear on the semantics.

Also fix a broken integration test which is only run in special
conditions.

[travis] Add test step for unic-ucd-normal
