### PR TITLE
[apps] Add unic-cli package, unic-echo binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.19.0
+  - 1.22.0
 
 branches:
   except:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "apps/cli/",
     "data/",
     "gen/",
     "unic/",

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "unic-cli"
+version = "0.6.0"
+authors = ["The UNIC Project Developers"]
+repository = "https://github.com/behnam/rust-unic/"
+license = "MIT/Apache-2.0"
+description = "UNIC Command-Line Tools"
+keywords = ["text", "unicode", "internationalization"]
+categories = ["internationalization", "text-processing", "parsing", "command-line-utilities"]
+readme = "README.md"
+
+
+[dependencies]
+unic-ucd = { path = "../../unic/ucd/", version = "0.6.0" }
+unic-char-property = { path = "../../unic/char/property/", version = "0.6.0" }
+
+clap = "2.27"
+lazy_static = "0.2"
+prettytable-rs = "0.6.7"
+regex = "0.2"
+
+[dev-dependencies]
+assert_cli = "0.5"
+quickcheck = "0.4"

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,105 @@
+# UNIC Command-Line Tools
+
+[![Crates.io](https://img.shields.io/crates/v/unic-cli.svg)](https://crates.io/crates/unic-cli)
+
+This package provides comman-line tools for developers, helping with common
+Unicode tasks, like generating, transforming, and inspecting strings.
+
+
+## How to Install
+
+Install the `unic-cli` package using [Cargo](https://doc.rust-lang.org/stable/cargo/).
+
+```bash
+$ cargo install unic-cli
+```
+
+
+## How to Use It
+
+### Echo Command
+
+The `unic-echo` command generates Unicode strings, similar to the common `echo`
+command.
+
+```bash
+# Normally, the output ends with a newline
+$ unic-echo Hello سلام
+Hello سلام
+
+# Get the codepoints or UTF-8/UTF-16, instead of plain text
+$ unic-echo Hello سلام -o codepoints
+U+0048 U+0065 U+006C U+006C U+006F U+0020 U+0633 U+0644 U+0627 U+0645
+
+# Or see how to escape as a Rust string literal
+$ unic-echo Hello سلام -o rust-escape
+"Hello \u{633}\u{644}\u{627}\u{645}"
+
+# Also the input can be in codepoints, or UTF-8/UTF-16 hex
+$ unic-echo -i codepoints U+0 U+20 U+41 U+A0 -o rust-escape
+"\u{0} A\u{a0}"
+
+$ unic-echo --help
+Write arguments to the standard output
+
+USAGE:
+    unic-echo [FLAGS] [OPTIONS] [STRINGS]...
+
+FLAGS:
+    -h, --help          Prints help information
+    -n, --no-newline    No trailing newline
+    -V, --version       Prints version information
+
+OPTIONS:
+    -i, --input <FORMAT>     Specify input format (see list below)
+    -o, --output <FORMAT>    Specify output format (see list below)
+
+ARGS:
+    <STRINGS>...    Input strings (expected valid Unicode)
+
+INPUT FORMATS:
+    plain                   Plain Unicode characters (default)
+    codepoints              Unicode codepoints (hex)
+    utf8-hex                UTF-8 bytes (hex)
+    utf16-hex               UTF-16 words (hex)
+
+OUTPUT FORMATS:
+    plain                   Plain Unicode characters (default)
+    codepoints              Unicode codepoints (hex)
+    utf8-hex                UTF-8 bytes (hex)
+    utf16-hex               UTF-16 words (hex)
+
+    braces-escape           String literal with \u{...} escapes for
+    | js6-escape            control and non-ASCII characters
+    | rust-escape
+
+    braces-escape-all       String literal with \u{...} escapes for
+    | js6-escape-all        all characters
+    | rust-escape-all
+
+    braces-escape-control   String literal with \u{...} escapes for
+    | js6-escape-control    control characters
+    | rust-escape-control
+```
+
+### Inspector Command
+
+The `unic-inspector` command lists the Unicode characters in the input string,
+along with their properties.
+
+```bash
+$ unic-inspector Hello سلام
+ H | U+0048 | LATIN CAPITAL LETTER H | Uppercase_Letter
+ e | U+0065 | LATIN SMALL LETTER E   | Lowercase_Letter
+ l | U+006C | LATIN SMALL LETTER L   | Lowercase_Letter
+ l | U+006C | LATIN SMALL LETTER L   | Lowercase_Letter
+ o | U+006F | LATIN SMALL LETTER O   | Lowercase_Letter
+   | U+0020 | SPACE                  | Space_Separator
+ س | U+0633 | ARABIC LETTER SEEN     | Other_Letter
+ ل | U+0644 | ARABIC LETTER LAM      | Other_Letter
+ ا | U+0627 | ARABIC LETTER ALEF     | Other_Letter
+ م | U+0645 | ARABIC LETTER MEEM     | Other_Letter
+```
+
+Soon, this tool will allow selecting which properties to show, as well as
+support grouping characters by Grapheme Clusters, Words, Sentenses, etc.

--- a/apps/cli/src/bin/unic-echo.rs
+++ b/apps/cli/src/bin/unic-echo.rs
@@ -1,0 +1,207 @@
+// Copyright 2017 The UNIC Project Developers.
+//
+// See the COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+#[macro_use]
+extern crate clap;
+
+#[macro_use]
+extern crate unic_cli;
+
+
+use std::io::{self, Write};
+
+use clap::{Arg, ErrorKind};
+
+use unic_cli::{parsers, writers, Result};
+
+
+unic_arg_enum!{
+    #[derive(Debug)]
+    enum InputFormat {
+        Plain,
+        // Unicode + UTF
+        Codepoint,
+        Codepoints,
+        Utf8Hex,
+        Utf16Hex
+    }
+}
+
+macro_rules! input_formats_help{
+    () => {"\
+INPUT FORMATS:
+    plain                   [default] Plain Unicode characters
+    codepoints              Unicode codepoints (hex)
+    utf8-hex                UTF-8 bytes (hex)
+    utf16-hex               UTF-16 words (hex)
+"
+    }
+}
+
+
+unic_arg_enum!{
+    #[derive(Debug)]
+    enum OutputFormat {
+        Plain,
+        // Unicode + UTF
+        Codepoint,
+        Codepoints,
+        Utf8Hex,
+        Utf16Hex,
+        // Braces Escapes
+        BracesEscape,
+        Js6Escape,
+        RustEscape,
+        // Braces Escape All
+        BracesEscapeAll,
+        Js6EscapeAll,
+        RustEscapeAll
+        /* TODO: Re-enable after rust-1.20.0
+        // Braces Escape Control
+        BracesEscapeControl,
+        Js6EscapeControl,
+        RustEscapeControl
+        */
+    }
+}
+
+macro_rules! output_formats_help{
+    () => {"\
+OUTPUT FORMATS:
+    plain                   [default] Plain Unicode characters
+    codepoints              Unicode codepoints (hex)
+    utf8-hex                UTF-8 bytes (hex)
+    utf16-hex               UTF-16 words (hex)
+
+    braces-escape           String literal with \\u{...} escapes for
+    | js6-escape            control and non-ASCII characters
+    | rust-escape
+
+    braces-escape-all       String literal with \\u{...} escapes for
+    | js6-escape-all        all characters
+    | rust-escape-all
+
+    braces-escape-control   String literal with \\u{...} escapes for
+    | js6-escape-control    control characters
+    | rust-escape-control
+"
+    }
+}
+
+
+fn main() {
+    run().expect("IO Error");
+}
+
+fn run() -> Result<()> {
+    let app = app_from_crate!()
+        .about(concat!(
+            env!("CARGO_PKG_DESCRIPTION"),
+            "\n\n",
+            "Write arguments to the standard output",
+        ))
+        .arg(
+            Arg::with_name("no_newline")
+                .short("n")
+                .long("no-newline")
+                .help("No trailing newline"),
+        )
+        .arg(
+            Arg::with_name("STRINGS")
+                .multiple(true)
+                .help("Input strings (expected valid Unicode)"),
+        )
+        .arg(
+            Arg::with_name("input_format")
+                .short("i")
+                .long("input")
+                .takes_value(true)
+                .value_name("FORMAT")
+                .help("Specify input format (see list below)"),
+        )
+        .arg(
+            Arg::with_name("output_format")
+                .short("o")
+                .long("output")
+                .takes_value(true)
+                .value_name("FORMAT")
+                .help("Specify output format (see list below)"),
+        )
+        .after_help(concat!(input_formats_help!(), "\n", output_formats_help!()));
+    let matches = app.get_matches();
+
+    // == Read input ==
+    let input: String = matches
+        .values_of("STRINGS")
+        .unwrap_or_default()
+        .collect::<Vec<&str>>()
+        .join(" ");
+
+    let input_format =
+        value_t!(matches, "input_format", InputFormat).unwrap_or_else(|err| match err.kind {
+            ErrorKind::ValueValidation => {
+                eprintln!("{}", matches.usage());
+                err.exit();
+            }
+            _ => InputFormat::Plain,
+        });
+
+    let string: String = match input_format {
+        InputFormat::Plain => input,
+        InputFormat::Codepoint | InputFormat::Codepoints => parsers::codepoints(&input),
+        InputFormat::Utf8Hex => parsers::utf8_hex(&input),
+        InputFormat::Utf16Hex => parsers::utf16_hex(&input),
+    };
+    let chars = string.chars();
+
+    // == Write output ==
+    let mut output = io::stdout();
+
+    let output_format =
+        value_t!(matches, "output_format", OutputFormat).unwrap_or_else(|err| match err.kind {
+            ErrorKind::ValueValidation => err.exit(),
+            _ => OutputFormat::Plain,
+        });
+
+    match output_format {
+        OutputFormat::Plain => write!(output, "{}", string)?,
+
+        // Unicode + UTF
+        OutputFormat::Codepoint | OutputFormat::Codepoints => {
+            writers::write_as_codepoints(&mut output, chars)?
+        }
+        OutputFormat::Utf8Hex => writers::write_as_utf8_hex(&mut output, chars)?,
+        OutputFormat::Utf16Hex => writers::write_as_utf16_hex(&mut output, chars)?,
+
+        // Escapes
+        OutputFormat::BracesEscape | OutputFormat::Js6Escape | OutputFormat::RustEscape => {
+            writers::write_with_control_n_unicode_braces_escape(&mut output, chars)?
+        }
+
+        OutputFormat::BracesEscapeAll |
+        OutputFormat::Js6EscapeAll |
+        OutputFormat::RustEscapeAll => writers::write_with_all_braces_escape(&mut output, chars)?,
+
+        /* TODO: Re-enable after rust-1.20.0
+        OutputFormat::BracesEscapeControl |
+        OutputFormat::Js6EscapeControl |
+        OutputFormat::RustEscapeControl => {
+            writers::write_with_control_braces_escape(&mut output, chars)?
+        }
+        */
+    };
+
+    if !matches.is_present("no_newline") {
+        writeln!(output)?;
+    }
+
+    Ok(())
+}

--- a/apps/cli/src/bin/unic-inspector.rs
+++ b/apps/cli/src/bin/unic-inspector.rs
@@ -1,0 +1,83 @@
+// Copyright 2017 The UNIC Project Developers.
+//
+// See the COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+#[macro_use]
+extern crate clap;
+#[macro_use]
+extern crate prettytable;
+
+extern crate unic_cli;
+extern crate unic_ucd;
+extern crate unic_char_property;
+
+
+use clap::Arg;
+use prettytable::format::TableFormat;
+use prettytable::Table;
+
+use unic_char_property::EnumeratedCharProperty;
+use unic_ucd::{GeneralCategory, Name};
+
+
+fn main() {
+    let app = app_from_crate!()
+        .about(concat!(
+            env!("CARGO_PKG_DESCRIPTION"),
+            "\n\n",
+            "Inspect characters and their properties",
+        ))
+        .arg(
+            Arg::with_name("STRINGS")
+                .help("Input strings (expected valid Unicode)")
+                .multiple(true),
+        );
+    let matches = app.get_matches();
+
+    // == Read input ==
+    let string: String = matches
+        .values_of("STRINGS")
+        .unwrap_or_default()
+        .collect::<Vec<&str>>()
+        .join(" ");
+
+    // == Write output ==
+    let mut table = Table::new();
+    let mut table_format = TableFormat::new();
+    table_format.padding(1, 1);
+    table_format.column_separator('|');
+    table.set_format(table_format);
+
+    /* TODO: Enable with option
+    table.set_titles(row![
+        cu -> " Char ",
+        cu -> " Code ",
+        cu -> " Name ",
+        cu -> " General_Category "
+    ]);
+    */
+
+    // TODO: Re-enable after rust-1.20.0
+    //string.chars().for_each(|chr| {
+    for chr in string.chars() {
+        let name = Name::of(chr)
+            .map(|n| n.to_string())
+            .unwrap_or("<none>".to_owned());
+
+        table.add_row(row![
+            cb  -> &format!("{}", chr),
+            rFr -> &format!("U+{:04X}", chr as u32),
+            l   -> &name,
+            l   -> &GeneralCategory::of(chr).long_name()
+        ]);
+    }
+
+    table.printstd();
+}

--- a/apps/cli/src/clap_macros.rs
+++ b/apps/cli/src/clap_macros.rs
@@ -1,0 +1,88 @@
+// Copyright 2017 The UNIC Project Developers.
+//
+// See the COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+#[macro_export]
+macro_rules! unic_arg_enum {
+    (@as_item $($i:item)*) => ($($i)*);
+
+    (@impls ( $($tts:tt)* ) -> ($e:ident, $($v:ident),+)) => {
+        unic_arg_enum!(@as_item
+        $($tts)*
+
+        impl ::std::str::FromStr for $e {
+            type Err = String;
+
+            fn from_str(s: &str) -> ::std::result::Result<Self,Self::Err> {
+                use ::std::ascii::AsciiExt;
+                match s {
+                    $(stringify!($v) |
+                    _ if s.replace("-", "").eq_ignore_ascii_case(stringify!($v)) => Ok($e::$v)),+,
+                    _ => Err({
+                        let v = vec![
+                            $(stringify!($v),)+
+                        ];
+                        format!("valid values: {}",
+                            v.join(" ,"))
+                    }),
+                }
+            }
+        }
+        impl ::std::fmt::Display for $e {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                match *self {
+                    $($e::$v => write!(f, stringify!($v)),)+
+                }
+            }
+        }
+        impl $e {
+            #[allow(dead_code)]
+            pub fn variants() -> [&'static str; _clap_count_exprs!($(stringify!($v)),+)] {
+                [
+                    $(stringify!($v),)+
+                ]
+            }
+        });
+    };
+
+    ($(#[$($m:meta),+])+ pub enum $e:ident { $($v:ident $(=$val:expr)*),+ } ) => {
+        unic_arg_enum!(@impls
+            ($(#[$($m),+])+
+            pub enum $e {
+                $($v$(=$val)*),+
+            }) -> ($e, $($v),+)
+        );
+    };
+
+    ($(#[$($m:meta),+])+ enum $e:ident { $($v:ident $(=$val:expr)*),+  } ) => {
+        unic_arg_enum!(@impls
+            ($(#[$($m),+])+
+            enum $e {
+                $($v$(=$val)*),+
+            }) -> ($e, $($v),+)
+        );
+    };
+
+    (pub enum $e:ident { $($v:ident $(=$val:expr)*),+ } ) => {
+        unic_arg_enum!(@impls
+            (pub enum $e {
+                $($v$(=$val)*),+
+            }) -> ($e, $($v),+)
+        );
+    };
+
+    (enum $e:ident { $($v:ident $(=$val:expr)*),+ } ) => {
+        unic_arg_enum!(@impls
+            (enum $e {
+                $($v$(=$val)*),+
+            }) -> ($e, $($v),+)
+        );
+    };
+}

--- a/apps/cli/src/lib.rs
+++ b/apps/cli/src/lib.rs
@@ -1,0 +1,24 @@
+// Copyright 2017 The UNIC Project Developers.
+//
+// See the COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+#[macro_use]
+extern crate lazy_static;
+extern crate regex;
+
+pub mod parsers;
+pub mod writers;
+
+pub mod clap_macros;
+
+
+use std::io;
+
+pub type Result<T> = ::std::result::Result<T, io::Error>;

--- a/apps/cli/src/parsers.rs
+++ b/apps/cli/src/parsers.rs
@@ -1,0 +1,77 @@
+// Copyright 2017 The UNIC Project Developers.
+//
+// See the COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+use std::char;
+use std::str;
+
+use regex::Regex;
+
+
+lazy_static! {
+    // Anything not alphanumeric or `+`
+    static ref CODEPOINT_SEPARATORS: Regex = Regex::new(r#"[^\w+]"#).unwrap();
+
+    // Unicode codepoint prefix: `U+`
+    static ref CODEPOINT_PREFIX: Regex = Regex::new(r#"^[Uu][+]"#).unwrap();
+
+    // Anything not alphanumeric
+    static ref HEX_SEPARATORS: Regex = Regex::new(r#"[^\w]"#).unwrap();
+
+    // Hex prefix: `0x`
+    static ref HEX_PREFIX: Regex = Regex::new(r#"^0[xX]"#).unwrap();
+}
+
+
+pub fn codepoints(string: &str) -> String {
+    CODEPOINT_SEPARATORS
+        .split(&string)
+        .map(|token| {
+            let mut token = token;
+            if CODEPOINT_PREFIX.is_match(token) {
+                token = &token[2..];
+            }
+            let codepoint = u32::from_str_radix(token, 16) //.
+                .expect(&format!("Cannot parse token as hex number: {}", token));
+            char::from_u32(codepoint) //.
+                .expect(&format!("Invalid Unicode Scalar Value code-point: {}", codepoint))
+        })
+        .collect::<String>()
+}
+
+
+pub fn utf8_hex(string: &str) -> String {
+    let utf8 = HEX_SEPARATORS.split(&string).map(|token| {
+        let mut token = token;
+        if HEX_PREFIX.is_match(token) {
+            token = &token[2..];
+        }
+        u8::from_str_radix(token, 16)
+            .expect(&format!("Cannot parse token as hex byte value: {}", token))
+    });
+
+    String::from_utf8(utf8.collect()).expect("Invalid UTF-8 sequence")
+}
+
+
+pub fn utf16_hex(string: &str) -> String {
+    let utf16 = HEX_SEPARATORS.split(&string).map(|token| {
+        let mut token = token;
+        if HEX_PREFIX.is_match(token) {
+            token = &token[2..];
+        }
+        u16::from_str_radix(token, 16)
+            .expect(&format!("Cannot parse token as hex byte value: {}", token))
+    });
+
+    char::decode_utf16(utf16)
+        .map(|r| r.expect("Invalid UTF-16 sequence"))
+        .collect()
+}

--- a/apps/cli/src/writers.rs
+++ b/apps/cli/src/writers.rs
@@ -1,0 +1,120 @@
+// Copyright 2017 The UNIC Project Developers.
+//
+// See the COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+use std::io;
+use std::str::Chars;
+
+
+use super::Result;
+
+
+// TODO: Replace with char::MAX_UTF*_LEN when available.
+const MAX_UTF8_LEN: usize = 4; // x u8 per char
+const MAX_UTF16_LEN: usize = 2; // x u16 per char
+
+
+macro_rules! write_join_with_space {
+    ($output:expr, $values:expr, $write_fn:expr) => {{
+        let mut first = true;
+        for v in $values {
+            if !first {
+                write!($output, " ")?;
+            }
+            first = false;
+            ($write_fn)($output, v)?;
+        }
+        Ok(())
+    }};
+}
+
+
+// == Single Char ==
+
+pub fn write_char_as_codepoint<W: io::Write>(output: &mut W, ch: char) -> Result<()> {
+    write!(output, "U+{:04X}", ch as u32)
+}
+
+
+pub fn write_char_as_utf8_hex<W: io::Write>(output: &mut W, ch: char) -> Result<()> {
+    let mut buf = [0; MAX_UTF8_LEN];
+    let utf8 = ch.encode_utf8(&mut buf).as_bytes();
+    write_join_with_space!(output, utf8.iter(), |output: &mut W, b8| -> Result<()> {
+        write!(output, "0x{:02X}", b8)
+    })
+}
+
+pub fn write_char_as_utf16_hex<W: io::Write>(output: &mut W, ch: char) -> Result<()> {
+    let mut buf = [0; MAX_UTF16_LEN];
+    let utf16 = ch.encode_utf16(&mut buf);
+    write_join_with_space!(output, utf16.iter(), |output: &mut W, b16| -> Result<()> {
+        write!(output, "0x{:04X}", b16)
+    })
+}
+
+
+// == Multiple Chars ==
+
+pub fn write_as_codepoints<'a, W: io::Write>(output: &mut W, chars: Chars<'a>) -> Result<()> {
+    write_join_with_space!(output, chars, write_char_as_codepoint)
+}
+
+
+
+pub fn write_as_utf8_hex<'a, W: io::Write>(output: &mut W, chars: Chars<'a>) -> Result<()> {
+    write_join_with_space!(output, chars, write_char_as_utf8_hex)
+}
+
+
+
+pub fn write_as_utf16_hex<'a, W: io::Write>(output: &mut W, chars: Chars<'a>) -> Result<()> {
+    write_join_with_space!(output, chars, write_char_as_utf16_hex)
+}
+
+
+pub fn write_with_control_n_unicode_braces_escape<'a, W: io::Write>(
+    output: &mut W,
+    chars: Chars<'a>,
+) -> Result<()> {
+    write!(output, "\"")?;
+    for ch in chars {
+        write!(output, "{}", ch.escape_default())?;
+    }
+    write!(output, "\"")?;
+    Ok(())
+}
+
+
+/* TODO: Re-enable after rust-1.20.0
+pub fn write_with_control_braces_escape<'a, W: io::Write>(
+    output: &mut W,
+    chars: Chars<'a>,
+) -> Result<()> {
+    write!(output, "\"")?;
+    for ch in chars {
+        write!(output, "{}", ch.escape_debug())?;
+    }
+    write!(output, "\"")?;
+    Ok(())
+}
+*/
+
+
+pub fn write_with_all_braces_escape<'a, W: io::Write>(
+    output: &mut W,
+    chars: Chars<'a>,
+) -> Result<()> {
+    write!(output, "\"")?;
+    for ch in chars {
+        write!(output, "{}", ch.escape_unicode())?;
+    }
+    write!(output, "\"")?;
+    Ok(())
+}

--- a/apps/cli/tests/quickcheck.rs
+++ b/apps/cli/tests/quickcheck.rs
@@ -1,0 +1,46 @@
+// Copyright 2017 The UNIC Project Developers.
+//
+// See the COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate quickcheck;
+
+extern crate unic_cli;
+
+
+use unic_cli::parsers;
+use unic_cli::writers;
+
+
+// Quickcheck parsers against writers
+quickcheck! {
+    fn quickcheck_codepoints(input: String) -> bool {
+        // 6 bytes for each BMP char, plus 1 SPACE
+        let mut printed = Vec::with_capacity(input.len() * 7);
+        writers::write_as_codepoints(&mut printed, input.chars()).unwrap();
+        let output = parsers::codepoints(&String::from_utf8(printed).unwrap());
+        input == output
+    }
+
+    fn quickcheck_utf8_hex(input: String) -> bool {
+        // 4 bytes for each ASCII char, plus 1 SPACE
+        let mut printed = Vec::with_capacity(input.len() * 5);
+        writers::write_as_utf8_hex(&mut printed, input.chars()).unwrap();
+        let output = parsers::utf8_hex(&String::from_utf8(printed).unwrap());
+        input == output
+    }
+
+    fn quickcheck_utf16_hex(input: String) -> bool {
+        // 6 bytes for each BMP char, plus 1 SPACE
+        let mut printed = Vec::with_capacity(input.len() * 7);
+        writers::write_as_utf16_hex(&mut printed, input.chars()).unwrap();
+        let output = parsers::utf16_hex(&String::from_utf8(printed).unwrap());
+        input == output
+    }
+}

--- a/apps/cli/tests/test_unic-echo.rs
+++ b/apps/cli/tests/test_unic-echo.rs
@@ -1,0 +1,287 @@
+// Copyright 2017 The UNIC Project Developers.
+//
+// See the COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate assert_cli;
+
+
+use assert_cli::Assert;
+
+
+// At the moment, there's no way to test stdout value for an exact string, therefore a mix of
+// `is()`, `contains()`, and `doesnt_contain()` is test trailing newline behavior.
+// See <https://github.com/killercup/assert_cli/issues/77> for details and updates.
+
+
+fn bin() -> Assert {
+    Assert::cargo_binary("unic-echo")
+}
+
+
+#[test]
+fn test_plain_text_input() {
+    fn run(args: &[&str]) -> Assert {
+        bin().with_args(args)
+    }
+
+    // No args
+    run(&[])
+        .stdout().is("") //.
+        .stdout().contains("\n") //.
+        .stdout().doesnt_contain("\n\n") //.
+        .unwrap();
+
+    // One arg
+    run(&["Hello"])
+        .stdout().is("Hello") //.
+        .stdout().contains("Hello\n") //.
+        .stdout().doesnt_contain("\nHello") //.
+        .stdout().doesnt_contain("Hello\n\n") //.
+        .unwrap();
+
+    // Two args
+    run(&["Hello", "World"])
+        .stdout().is("Hello World") //.
+        .stdout().contains("Hello World\n") //.
+        .stdout().doesnt_contain("\nHello") //.
+        .stdout().doesnt_contain("Hello World\n\n") //.
+        .unwrap();
+
+    // Valid UTF-8 args
+    run(&["Hello world!", "سلام به همه!"])
+        .stdout().is("Hello world! سلام به همه!") //.
+        .unwrap();
+
+    // Invalid UTF-8 args
+    // We cannot test invalid UTF-8 args via `assert_cli`.
+    // TODO: Find a way to test invalid UTF-8 args.
+}
+
+
+#[test]
+fn test_no_newline_output() {
+    fn run(args: &[&str]) -> Assert {
+        bin().with_args(&["--no-newline"]).with_args(args)
+    }
+
+    // No args
+    run(&[])
+        .stdout().is("") //.
+        .stdout().doesnt_contain("\n") //.
+        .unwrap();
+
+    // One arg
+    run(&["Hello"])
+        .stdout().is("Hello") //.
+        .stdout().doesnt_contain("Hello\n") //.
+        .unwrap();
+
+    // Two args
+    run(&["Hello", "World"])
+        .stdout().is("Hello World") //.
+        .stdout().doesnt_contain("Hello World\n") //.
+        .unwrap();
+}
+
+
+// == Input Formats ==
+
+#[test]
+fn test_codepoints_input() {
+    fn run(args: &[&str]) -> Assert {
+        bin().with_args(&["--input", "codepoints"]).with_args(args)
+    }
+
+    // No args
+    run(&[])
+        .stdout().is("") //.
+        .unwrap();
+
+    // One arg
+    run(&[
+        "48 U+65 U+006c U+0006c U+000000000006f", // Hello
+    ]).stdout().is("Hello") //.
+        .unwrap();
+
+    // Non-ASCII
+    run(&[
+        "633 0644 000627 0000000000000645", // سلام
+    ]).stdout().is("سلام") //.
+        .unwrap();
+}
+
+
+#[test]
+fn test_utf8_hex_input() {
+    fn run(args: &[&str]) -> Assert {
+        bin().with_args(&["--input", "utf8-hex"]).with_args(args)
+    }
+
+    // No args
+    run(&[])
+        .stdout().is("") //.
+        .unwrap();
+
+    // One arg
+    run(&[
+        "48 65 6c 6c 6f", // Hello
+    ]).stdout().is("Hello") //.
+        .unwrap();
+
+    // Two args
+    run(&[
+        "48 65 6c 6c 6f", // Hello
+        "20", // SPACE
+        "0x57 0x6f 0x72 0x6c 0x64", // World
+    ]).stdout().is("Hello World") //.
+        .unwrap();
+
+    // Missing trailing low digit
+    run(&[
+        "48 65 6c 6c 6", // Hell_
+    ]).stdout().is("Hell\u{6}") //.
+        .unwrap();
+
+    // Non-ASCII
+    run(&[
+        "D8 B3 D9 84 D8 A7 D9 85 0A", // سلام
+    ]).stdout().is("سلام") //.
+        .stdout().contains("سلام\n") //.
+        .unwrap();
+}
+
+
+#[test]
+fn test_utf16_hex_input() {
+    fn run(args: &[&str]) -> Assert {
+        bin().with_args(&["--input", "utf16-hex"]).with_args(args)
+    }
+
+    // Non-ASCII
+    run(&[
+        "0633 0x0644 0627,0645", // سلام
+    ]).stdout().is("سلام") //.
+        .stdout().contains("سلام\n") //.
+        .unwrap();
+}
+
+
+// == Output Formats ==
+
+#[test]
+fn test_codepoints_output() {
+    fn run(args: &[&str]) -> Assert {
+        bin().with_args(&["--output", "codepoints"]).with_args(args)
+    }
+
+    // No args
+    run(&[])
+        .stdout().is("") //.
+        .unwrap();
+
+    // One arg
+    run(&["Hello"])
+        .stdout().is("U+0048 U+0065 U+006C U+006C U+006F") //.
+        .unwrap();
+
+    // Non-ASCII
+    run(&["سلام"])
+        .stdout().is("U+0633 U+0644 U+0627 U+0645") //.
+        .unwrap();
+
+    // Non-BMP
+    run(&["\u{1F1FA}\u{1F1F3}\u{1F1EE}\u{1F1E8}\u{1F49F}"])
+        .stdout().is("U+1F1FA U+1F1F3 U+1F1EE U+1F1E8 U+1F49F") //.
+        .unwrap();
+}
+
+
+#[test]
+fn test_utf8_hex_output() {
+    fn run(args: &[&str]) -> Assert {
+        bin().with_args(&["--output", "utf8-hex"]).with_args(args)
+    }
+
+    // No args
+    run(&[])
+        .stdout().is("") //.
+        .unwrap();
+
+    // One arg
+    run(&["Hello"])
+        .stdout().is("0x48 0x65 0x6C 0x6C 0x6F") //.
+        .unwrap();
+
+    // Non-ASCII
+    run(&["سلام"])
+        .stdout().is("0xD8 0xB3 0xD9 0x84 0xD8 0xA7 0xD9 0x85") //.
+        .unwrap();
+
+    // Non-BMP
+    run(&["\u{1F49F}"])
+        .stdout().is("0xF0 0x9F 0x92 0x9F") //.
+        .unwrap();
+}
+
+
+#[test]
+fn test_utf16_hex_output() {
+    fn run(args: &[&str]) -> Assert {
+        bin().with_args(&["--output", "utf16-hex"]).with_args(args)
+    }
+
+    // No args
+    run(&[])
+        .stdout().is("") //.
+        .unwrap();
+
+    // One arg
+    run(&["Hello"])
+        .stdout().is("0x0048 0x0065 0x006C 0x006C 0x006F") //.
+        .unwrap();
+
+    // Non-ASCII
+    run(&["سلام"])
+        .stdout().is("0x0633 0x0644 0x0627 0x0645") //.
+        .unwrap();
+
+    // Non-BMP
+    run(&["\u{1F1FA}\u{1F1F3}\u{1F1EE}\u{1F1E8}\u{1F49F}"])
+        .stdout().is("0xD83C 0xDDFA 0xD83C 0xDDF3 0xD83C 0xDDEE 0xD83C 0xDDE8 0xD83D 0xDC9F") //.
+        .unwrap();
+}
+
+#[test]
+fn test_rust_escape_output() {
+    fn run(args: &[&str]) -> Assert {
+        bin()
+            .with_args(&["--output", "rust-escape"])
+            .with_args(args)
+    }
+
+    // No args
+    run(&[])
+        .stdout().is("\"\"") //.
+        .unwrap();
+
+    // One arg
+    run(&["Hello"])
+        .stdout().is("\"Hello\"") //.
+        .unwrap();
+
+    // Non-ASCII
+    run(&["hello", "سلام"])
+        .stdout().is("\"hello \\u{633}\\u{644}\\u{627}\\u{645}\"") //.
+        .unwrap();
+
+    // Non-BMP
+    run(&["\u{1f1fa}\u{1f1f3}\u{1f1ee}\u{1f1e8}\u{1f49f}"])
+        .stdout().is("\"\\u{1f1fa}\\u{1f1f3}\\u{1f1ee}\\u{1f1e8}\\u{1f49f}\"") //.
+        .unwrap();
+}


### PR DESCRIPTION
`unic-cli` package provides comman-line tools for developers, helping
with common Unicode tasks, like generating, inspecting, and transforming
strings.

`unic-echo` is a command-line tool, similar to the common `echo`
command, producing Unicode strings, with support for common escaping
forms for input and output.

`unic-inspector` is a command-line tool to inspect Unicode strings
per-character.
