### PR TITLE
Add gh-pages doc upload to nightly build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,10 +46,9 @@ script:
 
 # TODO: - rustdoc --test README.md -L target/debug -L target/debug/deps
 
-# TODO: Enable auto update for gh-pages
-#after_success: |
-#  cargo doc && \
-#  echo '<meta http-equiv="refresh" content="0;url=YOURLIBNAME/index.html">' > target/doc/index.html && \
-#  sudo pip install ghp-import && \
-#  ghp-import -n target/doc && \
-#  git push -qf https://${GITHUB_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages
+after_success:
+  # upload gh-pages documentation
+  - test "$TRAVIS_RUST_VERSION" != "nightly" ||
+    (cargo doc --verbose --all --all-features &&
+     cargo install cargo-travis &&
+     cargo doc-upload --branch master)


### PR DESCRIPTION
@behnam you'll need to add a `$GH_TOKEN` to Travis for this to work.

> In order to generate a GitHub token, navigate to [your tokens settings page](https://github.com/settings/tokens). While you're there, review your currently issued tokens, and revoke those that you're no longer using. Generate a new token, give it a descriptive name (this can be edited later) (I suggest `repo-name-doc-upload`) and the `public_repo` scope (this can be edited later). Make sure to copy the token once it's generated, as you will never be able to see it again (though you can regenerate it)! This token gives anyone with the token access to act as you when read/writing to any public repository you have the permission to read/write to, so keep it safe. Add it to the GH_TOKEN environment variable on Travis and _make sure that "Display value in build log" is set to off_.
>
> - [CAD97 on Great Rust CI](https://dev.to/cad97/great-rust-ci-1fk6)