### PR TITLE
Release v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ In `Cargo.toml`:
 
 ```toml
 [dependencies]
-unic = "0.6.0"  # This has Unicode 10.0.0 data and algorithms
+unic = "0.7.0"  # This has Unicode 10.0.0 data and algorithms
 ```
 
 And in `main.rs`:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ this crate.
 
 ### Major Components
 
--   [`unic-char`](char): Unicode Character Tools.
+-   [`unic-char`](unic/char/): Unicode Character Tools.
     [![Crates.io](https://img.shields.io/crates/v/unic-char.svg)](https://crates.io/crates/unic-char/)
 
 -   [`unic-ucd`](unic/ucd/): Unicode Character Database
@@ -111,6 +111,11 @@ this crate.
 -   [`unic-emoji`](unic/emoji/): Unicode Emoji
     ([UTS\#51](https://unicode.org/reports/tr51/)).
     [![Crates.io](https://img.shields.io/crates/v/unic-emoji.svg)](https://crates.io/crates/unic-emoji/)
+
+### Applications
+
+-   [`unic-cli`](apps/cli): UNIC Command-Line Tools
+    [![Crates.io](https://img.shields.io/crates/v/unic-cli.svg)](https://crates.io/crates/unic-cli/)
 
 ## Code Organization: Combined Repository
 

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-cli"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -11,7 +11,7 @@ readme = "README.md"
 
 
 [dependencies]
-unic = { path = "../../unic/", version = "0.6.0" }
+unic = { path = "../../unic/", version = "0.7.0" }
 
 clap = "2.29"
 lazy_static = "1.0"

--- a/etc/common.sh
+++ b/etc/common.sh
@@ -17,8 +17,8 @@ set -e
 export COMPONENTS="
     unic/common
 
-    unic/char/property
     unic/char/range
+    unic/char/property
     unic/char
 
     unic/ucd/version
@@ -47,6 +47,11 @@ export COMPONENTS="
     unic/emoji
 
     unic
+"
+
+# List of apps, in order of dependency
+export APPS="
+    apps/cli
 "
 
 -() {

--- a/etc/publish-all.sh
+++ b/etc/publish-all.sh
@@ -25,8 +25,16 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Steps
 
-# Publish all components (ignore failures, because of the version being released already)
+# Publish all components
 for component in $COMPONENTS; do
     - cargo update  --verbose --manifest-path "$component/Cargo.toml"
+    # ignore failures, because of the version being released already
+    - cargo publish --verbose --manifest-path "$component/Cargo.toml" || true
+done
+
+# Publish all apps
+for app in $APPS; do
+    - cargo update  --verbose --manifest-path "$component/Cargo.toml"
+    # ignore failures, because of the version being released already
     - cargo publish --verbose --manifest-path "$component/Cargo.toml" || true
 done

--- a/gen/Cargo.toml
+++ b/gen/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
-unic-char-range = { path = "../unic/char/range/", version = "0.6.0" }
+unic-char-range = { path = "../unic/char/range/", version = "0.7.0" }
 
 # Command line argument parsing
 clap = "2.29"

--- a/unic/Cargo.toml
+++ b/unic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -19,14 +19,14 @@ bench_it = ["unic-bidi/bench_it"]
 serde = ["unic-bidi/serde"]
 
 [dependencies]
-unic-bidi = { path = "bidi/", version = "0.6.0" }
-unic-char = { path = "char/", version = "0.6.0", features = ["std"] }
-unic-common = { path = "common/", version = "0.6.0" }
-unic-emoji = { path = "emoji/", version = "0.6.0" }
-unic-idna = { path = "idna/", version = "0.6.0" }
-unic-normal = { path = "normal/", version = "0.6.0" }
-unic-segment = { path = "segment/", version = "0.6.0" }
-unic-ucd = { path = "ucd/", version = "0.6.0" }
+unic-bidi = { path = "bidi/", version = "0.7.0" }
+unic-char = { path = "char/", version = "0.7.0", features = ["std"] }
+unic-common = { path = "common/", version = "0.7.0" }
+unic-emoji = { path = "emoji/", version = "0.7.0" }
+unic-idna = { path = "idna/", version = "0.7.0" }
+unic-normal = { path = "normal/", version = "0.7.0" }
+unic-segment = { path = "segment/", version = "0.7.0" }
+unic-ucd = { path = "ucd/", version = "0.7.0" }
 
 [badges]
 appveyor = { repository = "behnam/rust-unic", branch = "master", service = "github" }

--- a/unic/bidi/Cargo.toml
+++ b/unic/bidi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-bidi"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -25,9 +25,9 @@ bench_it = []
 [dependencies]
 matches = "0.1"
 serde = { version = ">=0.8, <2.0", optional = true, features = ["derive"] }
-unic-ucd-bidi = { path = "../ucd/bidi/", version = "0.6.0" }
+unic-ucd-bidi = { path = "../ucd/bidi/", version = "0.7.0" }
 
 [dev-dependencies]
 serde_test = ">=0.8, <2.0"
-unic-char-property = { path = "../char/property/", version = "0.6.0" }
-unic-ucd-version = { path = "../ucd/version/", version = "0.6.0" }
+unic-char-property = { path = "../char/property/", version = "0.7.0" }
+unic-ucd-version = { path = "../ucd/version/", version = "0.7.0" }

--- a/unic/char/Cargo.toml
+++ b/unic/char/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-char"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -20,5 +20,5 @@ std = ["unic-char-range/std"]
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
-unic-char-property = { path = "property/", version = "0.6.0" }
-unic-char-range = { path = "range/", version = "0.6.0" }
+unic-char-property = { path = "property/", version = "0.7.0" }
+unic-char-range = { path = "range/", version = "0.7.0" }

--- a/unic/char/property/Cargo.toml
+++ b/unic/char/property/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-char-property"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -12,7 +12,7 @@ categories = ["internationalization", "text-processing", "parsing"]
 exclude = []
 
 [dependencies]
-unic-char-range = { path = "../range/", version = "0.6.0" }
+unic-char-range = { path = "../range/", version = "0.7.0" }
 
 [badges]
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }

--- a/unic/char/range/Cargo.toml
+++ b/unic/char/range/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-char-range"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"

--- a/unic/common/Cargo.toml
+++ b/unic/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-common"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"

--- a/unic/emoji/Cargo.toml
+++ b/unic/emoji/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-emoji"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -15,4 +15,4 @@ exclude = []
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
-unic-emoji-char = { path = "char/", version = "0.6.0" }
+unic-emoji-char = { path = "char/", version = "0.7.0" }

--- a/unic/emoji/char/Cargo.toml
+++ b/unic/emoji/char/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-emoji-char"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -15,6 +15,6 @@ exclude = []
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
-unic-char-property = { path = "../../char/property/", version = "0.6.0" }
-unic-char-range = { path = "../../char/range", version = "0.6.0" }
-unic-ucd-version = { path = "../../ucd/version/", version = "0.6.0" }
+unic-char-property = { path = "../../char/property/", version = "0.7.0" }
+unic-char-range = { path = "../../char/range", version = "0.7.0" }
+unic-ucd-version = { path = "../../ucd/version/", version = "0.7.0" }

--- a/unic/idna/Cargo.toml
+++ b/unic/idna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-idna"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -17,9 +17,9 @@ travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
 matches = "0.1"
-unic-idna-punycode = { path = "punycode/", version = "0.6.0" }
-unic-idna-mapping = { path = "mapping/", version = "0.6.0" }
-unic-normal = { path = "../normal/", version = "0.6.0" }
-unic-ucd-bidi = { path = "../ucd/bidi/", version = "0.6.0" }
-unic-ucd-normal = { path = "../ucd/normal/", version = "0.6.0" }
-unic-ucd-version = { path = "../ucd/version/", version = "0.6.0" }
+unic-idna-punycode = { path = "punycode/", version = "0.7.0" }
+unic-idna-mapping = { path = "mapping/", version = "0.7.0" }
+unic-normal = { path = "../normal/", version = "0.7.0" }
+unic-ucd-bidi = { path = "../ucd/bidi/", version = "0.7.0" }
+unic-ucd-normal = { path = "../ucd/normal/", version = "0.7.0" }
+unic-ucd-version = { path = "../ucd/version/", version = "0.7.0" }

--- a/unic/idna/mapping/Cargo.toml
+++ b/unic/idna/mapping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-idna-mapping"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -15,6 +15,6 @@ exclude = []
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
-unic-char-range = { path = "../../char/range/", version = "0.6.0" }
-unic-char-property = { path = "../../char/property/", version = "0.6.0" }
-unic-ucd-version = { path = "../../ucd/version/", version = "0.6.0" }
+unic-char-range = { path = "../../char/range/", version = "0.7.0" }
+unic-char-property = { path = "../../char/property/", version = "0.7.0" }
+unic-ucd-version = { path = "../../ucd/version/", version = "0.7.0" }

--- a/unic/idna/punycode/Cargo.toml
+++ b/unic/idna/punycode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-idna-punycode"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"

--- a/unic/normal/Cargo.toml
+++ b/unic/normal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-normal"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -16,7 +16,7 @@ exclude = ["tests/conformance_tests.rs"]
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
-unic-ucd-normal = { path = "../ucd/normal/", version = "0.6.0" }
+unic-ucd-normal = { path = "../ucd/normal/", version = "0.7.0" }
 
 [dev-dependencies]
-unic-ucd-version = { path = "../ucd/version/", version = "0.6.0" }
+unic-ucd-version = { path = "../ucd/version/", version = "0.7.0" }

--- a/unic/segment/Cargo.toml
+++ b/unic/segment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-segment"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -16,8 +16,8 @@ exclude = []
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
-unic-ucd-segment = { path = "../ucd/segment/", version = "0.6.0" }
+unic-ucd-segment = { path = "../ucd/segment/", version = "0.7.0" }
 
 [dev-dependencies]
 quickcheck = "0.6"
-unic-ucd-common = { path = "../ucd/common/", version = "0.6.0" }
+unic-ucd-common = { path = "../ucd/common/", version = "0.7.0" }

--- a/unic/ucd/Cargo.toml
+++ b/unic/ucd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -16,18 +16,18 @@ exclude = []
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
-unic-ucd-age = { path = "age/", version = "0.6.0" }
-unic-ucd-bidi = { path = "bidi/", version = "0.6.0" }
-unic-ucd-case = { path = "case/", version = "0.6.0" }
-unic-ucd-category = { path = "category/", version = "0.6.0" }
-unic-ucd-common = { path = "common/", version = "0.6.0" }
-unic-ucd-ident = { path = "ident/", version = "0.6.0" }
-unic-ucd-name = { path = "name/", version = "0.6.0" }
-unic-ucd-normal = { path = "normal/", version = "0.6.0", features = ["unic-ucd-category"] }
-unic-ucd-segment = { path = "segment/", version = "0.6.0" }
-unic-ucd-version = { path = "version/", version = "0.6.0" }
+unic-ucd-age = { path = "age/", version = "0.7.0" }
+unic-ucd-bidi = { path = "bidi/", version = "0.7.0" }
+unic-ucd-case = { path = "case/", version = "0.7.0" }
+unic-ucd-category = { path = "category/", version = "0.7.0" }
+unic-ucd-common = { path = "common/", version = "0.7.0" }
+unic-ucd-ident = { path = "ident/", version = "0.7.0" }
+unic-ucd-name = { path = "name/", version = "0.7.0" }
+unic-ucd-normal = { path = "normal/", version = "0.7.0", features = ["unic-ucd-category"] }
+unic-ucd-segment = { path = "segment/", version = "0.7.0" }
+unic-ucd-version = { path = "version/", version = "0.7.0" }
 
 [dev-dependencies]
-unic-char-range = { path = "../char/range/", version = "0.6.0" }
-unic-char-property = { path = "../char/property/", version = "0.6.0" }
+unic-char-range = { path = "../char/range/", version = "0.7.0" }
+unic-char-property = { path = "../char/property/", version = "0.7.0" }
 matches = "0.1"

--- a/unic/ucd/age/Cargo.toml
+++ b/unic/ucd/age/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-age"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -15,6 +15,6 @@ exclude = []
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
-unic-char-property = { path = "../../char/property/", version = "0.6.0" }
-unic-char-range = { path = "../../char/range", version = "0.6.0" }
-unic-ucd-version = { path = "../version/", version = "0.6.0" }
+unic-char-property = { path = "../../char/property/", version = "0.7.0" }
+unic-char-range = { path = "../../char/range", version = "0.7.0" }
+unic-ucd-version = { path = "../version/", version = "0.7.0" }

--- a/unic/ucd/bidi/Cargo.toml
+++ b/unic/ucd/bidi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-bidi"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -15,6 +15,6 @@ exclude = []
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
-unic-char-property = { path = "../../char/property/", version = "0.6.0" }
-unic-char-range = { path = "../../char/range", version = "0.6.0" }
-unic-ucd-version = { path = "../version/", version = "0.6.0" }
+unic-char-property = { path = "../../char/property/", version = "0.7.0" }
+unic-char-range = { path = "../../char/range", version = "0.7.0" }
+unic-ucd-version = { path = "../version/", version = "0.7.0" }

--- a/unic/ucd/case/Cargo.toml
+++ b/unic/ucd/case/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-case"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -15,6 +15,6 @@ exclude = []
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
-unic-char-property = { path = "../../char/property/", version = "0.6.0" }
-unic-char-range = { path = "../../char/range", version = "0.6.0" }
-unic-ucd-version = { path = "../version/", version = "0.6.0" }
+unic-char-property = { path = "../../char/property/", version = "0.7.0" }
+unic-char-range = { path = "../../char/range", version = "0.7.0" }
+unic-ucd-version = { path = "../version/", version = "0.7.0" }

--- a/unic/ucd/category/Cargo.toml
+++ b/unic/ucd/category/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-category"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -16,6 +16,6 @@ travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
 matches = "0.1"
-unic-char-property = { path = "../../char/property/", version = "0.6.0" }
-unic-char-range = { path = "../../char/range", version = "0.6.0" }
-unic-ucd-version = { path = "../version/", version = "0.6.0" }
+unic-char-property = { path = "../../char/property/", version = "0.7.0" }
+unic-char-range = { path = "../../char/range", version = "0.7.0" }
+unic-ucd-version = { path = "../version/", version = "0.7.0" }

--- a/unic/ucd/common/Cargo.toml
+++ b/unic/ucd/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-common"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -15,9 +15,9 @@ exclude = []
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
-unic-char-property = { path = "../../char/property/", version = "0.6.0" }
-unic-char-range = { path = "../../char/range", version = "0.6.0" }
-unic-ucd-version = { path = "../version/", version = "0.6.0" }
+unic-char-property = { path = "../../char/property/", version = "0.7.0" }
+unic-char-range = { path = "../../char/range", version = "0.7.0" }
+unic-ucd-version = { path = "../version/", version = "0.7.0" }
 
 [dev-dependencies]
-unic-ucd-category = { path = "../category/", version = "0.6.0" }
+unic-ucd-category = { path = "../category/", version = "0.7.0" }

--- a/unic/ucd/ident/Cargo.toml
+++ b/unic/ucd/ident/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-ident"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -22,11 +22,11 @@ id = []
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
-unic-char-property = { path = "../../char/property/", version = "0.6.0" }
-unic-char-range = { path = "../../char/range", version = "0.6.0" }
-unic-ucd-version = { path = "../version/", version = "0.6.0" }
+unic-char-property = { path = "../../char/property/", version = "0.7.0" }
+unic-char-range = { path = "../../char/range", version = "0.7.0" }
+unic-ucd-version = { path = "../version/", version = "0.7.0" }
 
 [dev-dependencies]
-unic-ucd-category = { path = "../category/", version = "0.6.0" }
+unic-ucd-category = { path = "../category/", version = "0.7.0" }
 regex = "0.2"
 matches = "0.1"

--- a/unic/ucd/name/Cargo.toml
+++ b/unic/ucd/name/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-name"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -15,5 +15,5 @@ exclude = []
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
-unic-ucd-version = { path = "../version/", version = "0.6.0" }
-unic-char-property = { path = "../../char/property/", version = "0.6.0" }
+unic-ucd-version = { path = "../version/", version = "0.7.0" }
+unic-char-property = { path = "../../char/property/", version = "0.7.0" }

--- a/unic/ucd/normal/Cargo.toml
+++ b/unic/ucd/normal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-normal"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -15,13 +15,13 @@ exclude = ["tests/conformance_tests.rs"]
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
-unic-char-property = { path = "../../char/property/", version = "0.6.0" }
-unic-char-range = { path = "../../char/range", version = "0.6.0" }
-unic-ucd-category = { path = "../category/", version = "0.6.0", optional = true }
-unic-ucd-version = { path = "../version/", version = "0.6.0" }
+unic-char-property = { path = "../../char/property/", version = "0.7.0" }
+unic-char-range = { path = "../../char/range", version = "0.7.0" }
+unic-ucd-category = { path = "../category/", version = "0.7.0", optional = true }
+unic-ucd-version = { path = "../version/", version = "0.7.0" }
 
 [dev-dependencies]
-unic-ucd-category = { path = "../category/", version = "0.6.0" }
+unic-ucd-category = { path = "../category/", version = "0.7.0" }
 
 [features]
 default = []

--- a/unic/ucd/segment/Cargo.toml
+++ b/unic/ucd/segment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-segment"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -15,6 +15,6 @@ exclude = []
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
-unic-char-property = { path = "../../char/property/", version = "0.6.0" }
-unic-char-range = { path = "../../char/range", version = "0.6.0" }
-unic-ucd-version = { path = "../version/", version = "0.6.0" }
+unic-char-property = { path = "../../char/property/", version = "0.7.0" }
+unic-char-range = { path = "../../char/range", version = "0.7.0" }
+unic-ucd-version = { path = "../version/", version = "0.7.0" }

--- a/unic/ucd/version/Cargo.toml
+++ b/unic/ucd/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-version"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/behnam/rust-unic/"
 license = "MIT/Apache-2.0"
@@ -15,4 +15,4 @@ exclude = []
 travis-ci = { repository = "behnam/rust-unic", branch = "master" }
 
 [dependencies]
-unic-common = { path = "../../common/", version = "0.6.0" }
+unic-common = { path = "../../common/", version = "0.7.0" }


### PR DESCRIPTION
# UNIC Applications

UNIC Applications are binary creates hosting in the same repository as `unic` super-crate, under the `apps/` directory. These creates are not internal parts of the `unic` library, but tools designed and developed for the general audience, also serving as a test bed for the UNIC API. We are starting with CLI applications, and possibly expanding it to GUI and WEB applications, as well.

- [`unic-cli`] The new UNIC CLI application provides command-line tools for working with Unicode characters and strings. In this release, first versions of `unic-echo` and `unic-inspector` commands are implemented.

# New Components

## Character Property

- [`unic-ucd-common `] Common character properties (*alphabetic*, *alphanumeric*, *control*, *numeric*, and *white_space*).
- [`unic-ucd-ident`] Unicode Identifier character properties.
- [`unic-ucd-segment`] Unicode Segmentation character properties.
- [`unic-emoji-char`] Unicode Emoji character properties.

## String Algorithm

- [`unic-segment`] Implementation of Unicode Text Segmentation algorithms (*Grapheme Cluster* and *Word* boundaries).

# Other Updates

This release was delayed for a couple of cycles, because of the problems with running tests in a workspace with a mix of std and no-std creates. The issue is resolved as of `1.22.0`.

- Enable `no_std` for many of the existing components.
- Bumped minimum Rust to `1.22.0`.
- Lots of small fixes for data types and internal structure updates.