### PR TITLE
Add lint attributes to components

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,8 +1,8 @@
-array_layout = "Block"
-array_width = 80
-fn_args_layout = "Block"
-fn_brace_style = "SameLineWhere"
-fn_call_style = "Block"
-generics_indent = "Block"
+brace_style = "SameLineWhere"
 imports_indent = "Block"
 imports_layout = "HorizontalVertical"
+indent_style = "Block"
+max_width = 100
+reorder_imported_names = true
+reorder_imports = true
+reorder_imports_in_group = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ script:
     cargo test  --verbose --all --all-features
 
   # This takes too long, let's disable for now.
-  # - test "$TRAVIS_RUST_VERSION" != "nightly" ||
-  #   cargo bench --verbose --all --features 'bench_it'
+  - test "$TRAVIS_RUST_VERSION" != "nightly" ||
+    cargo build --benches --verbose --all --features 'bench_it'
 
 # TODO: - rustdoc --test README.md -L target/debug -L target/debug/deps
 

--- a/apps/cli/src/bin/unic-inspector.rs
+++ b/apps/cli/src/bin/unic-inspector.rs
@@ -18,8 +18,8 @@ extern crate unic;
 extern crate unic_cli;
 
 use clap::Arg;
-use prettytable::format::TableFormat;
 use prettytable::Table;
+use prettytable::format::TableFormat;
 
 use unic::char::property::EnumeratedCharProperty;
 use unic::ucd::{GeneralCategory, Name};

--- a/etc/check-components.sh
+++ b/etc/check-components.sh
@@ -29,6 +29,11 @@ for component in $COMPONENTS; do
     pkg_info_rs="$component/src/pkg_info.rs"
 
     # Require library attribute settings
+    # TODO:
+    #   warnings (all lints that are set to issue warnings)
+    #   missing-copy-implementations
+    #   unreachable-pub
+    #   unused-results
     ATTRS='
         bad_style
         future_incompatible
@@ -37,7 +42,6 @@ for component in $COMPONENTS; do
         unconditional_recursion
         unsafe_code
         unused
-        unused_imports
     '
     for attr in $ATTRS; do
         if grep --quiet "$attr" $lib_rs; then true; else

--- a/etc/check-components.sh
+++ b/etc/check-components.sh
@@ -27,15 +27,20 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Check all components
 for component in $COMPONENTS; do
-
-    # Require Documentation
     lib_rs="$component/src/lib.rs"
+    pkg_info_rs="$component/src/pkg_info.rs"
+
+    # Require Documentation Enforcement
     if grep --quiet 'missing_docs' $lib_rs; then true; else
-        echo "$component: missing 'missing_docs' forbid/deny"
+        echo "$component: missing 'missing_docs' config"
+    fi
+
+    # Require Safety Enforcement
+    if grep --quiet 'unsafe_code' $lib_rs; then true; else
+        echo "$component: missing 'unsafe_code' config"
     fi
 
     # Package Info
-    pkg_info_rs="$component/src/pkg_info.rs"
     if [ ! -f "$pkg_info_rs" ]; then
         echo "$component: missing 'pkg_info.rs'"
     fi

--- a/etc/check-components.sh
+++ b/etc/check-components.sh
@@ -25,11 +25,19 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Steps
 
-# Package all components
+# Check all components
 for component in $COMPONENTS; do
-    pkg_file="$component/src/pkg_info.rs"
-    if [ ! -f "$pkg_file" ]
-    then
-        echo "Missing pkg_file: $component"
+
+    # Require Documentation
+    lib_rs="$component/src/lib.rs"
+    if grep --quiet 'missing_docs' $lib_rs; then true; else
+        echo "$component: missing 'missing_docs' forbid/deny"
     fi
+
+    # Package Info
+    pkg_info_rs="$component/src/pkg_info.rs"
+    if [ ! -f "$pkg_info_rs" ]; then
+        echo "$component: missing 'pkg_info.rs'"
+    fi
+
 done

--- a/etc/check-components.sh
+++ b/etc/check-components.sh
@@ -23,22 +23,27 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . "$DIR/common.sh"
 
 
-# Steps
-
 # Check all components
 for component in $COMPONENTS; do
     lib_rs="$component/src/lib.rs"
     pkg_info_rs="$component/src/pkg_info.rs"
 
-    # Require Documentation Enforcement
-    if grep --quiet 'missing_docs' $lib_rs; then true; else
-        echo "$component: missing 'missing_docs' config"
-    fi
-
-    # Require Safety Enforcement
-    if grep --quiet 'unsafe_code' $lib_rs; then true; else
-        echo "$component: missing 'unsafe_code' config"
-    fi
+    # Require library attribute settings
+    ATTRS='
+        bad_style
+        future_incompatible
+        missing_debug_implementations
+        missing_docs
+        unconditional_recursion
+        unsafe_code
+        unused
+        unused_imports
+    '
+    for attr in $ATTRS; do
+        if grep --quiet "$attr" $lib_rs; then true; else
+            echo "$component: missing '$attr' attribute setting"
+        fi
+    done
 
     # Package Info
     if [ ! -f "$pkg_info_rs" ]; then

--- a/gen/src/source/idna/idna_mapping_table.rs
+++ b/gen/src/source/idna/idna_mapping_table.rs
@@ -9,8 +9,8 @@
 // except according to those terms.
 
 use std::char;
-use std::str::FromStr;
 use std::collections::BTreeMap;
+use std::str::FromStr;
 
 use regex::Regex;
 

--- a/gen/src/writer/emoji/char.rs
+++ b/gen/src/writer/emoji/char.rs
@@ -10,8 +10,8 @@
 
 use std::path::Path;
 
-use source::emoji::readme::{EmojiDataVersion, EMOJI_VERSION};
 use source::emoji::emoji_data::EMOJI_DATA;
+use source::emoji::readme::{EmojiDataVersion, EMOJI_VERSION};
 
 use writer::utils::tables::ToRangeCharSet;
 use writer::utils::write;

--- a/gen/src/writer/idna/mapping.rs
+++ b/gen/src/writer/idna/mapping.rs
@@ -10,8 +10,8 @@
 
 use std::path::Path;
 
-use source::idna::readme::UNICODE_VERSION;
 use source::idna::idna_mapping_table::IDNA_MAPPING;
+use source::idna::readme::UNICODE_VERSION;
 
 use writer::common::emit_unicode_version;
 use writer::utils::tables::ToRangeCharTable;

--- a/gen/src/writer/ucd/age.rs
+++ b/gen/src/writer/ucd/age.rs
@@ -14,9 +14,9 @@ use std::path::Path;
 use source::ucd::derived_age::AGE_DATA;
 use source::ucd::readme::UNICODE_VERSION;
 
+use writer::common::emit_unicode_version;
 use writer::utils::tables::ToRangeCharTable;
 use writer::utils::write;
-use writer::common::emit_unicode_version;
 
 pub fn generate(dir: &Path) {
     emit_unicode_version(dir, &UNICODE_VERSION);

--- a/gen/src/writer/ucd/bidi.rs
+++ b/gen/src/writer/ucd/bidi.rs
@@ -13,12 +13,12 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Display;
 use std::path::Path;
 
-use source::ucd::unicode_data::UNICODE_DATA;
 use source::ucd::prop_list::PROP_LIST;
 use source::ucd::readme::UNICODE_VERSION;
+use source::ucd::unicode_data::UNICODE_DATA;
 
-use writer::utils::tables::{ToRangeCharSet, ToRangeCharTable};
 use writer::common::emit_unicode_version;
+use writer::utils::tables::{ToRangeCharSet, ToRangeCharTable};
 use writer::utils::write;
 
 pub fn generate(dir: &Path) {

--- a/gen/src/writer/ucd/case.rs
+++ b/gen/src/writer/ucd/case.rs
@@ -13,8 +13,8 @@ use std::path::Path;
 use source::ucd::derived_core_properties::DERIVED_CORE_PROPERTIES;
 use source::ucd::readme::UNICODE_VERSION;
 
-use writer::utils::tables::ToRangeCharSet;
 use writer::common::emit_unicode_version;
+use writer::utils::tables::ToRangeCharSet;
 use writer::utils::write;
 
 pub fn generate(dir: &Path) {

--- a/gen/src/writer/ucd/category.rs
+++ b/gen/src/writer/ucd/category.rs
@@ -13,11 +13,11 @@ use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::path::Path;
 
-use source::ucd::unicode_data::UNICODE_DATA;
 use source::ucd::readme::UNICODE_VERSION;
+use source::ucd::unicode_data::UNICODE_DATA;
 
-use writer::utils::tables::ToRangeCharTable;
 use writer::common::emit_unicode_version;
+use writer::utils::tables::ToRangeCharTable;
 use writer::utils::write;
 
 pub fn generate(dir: &Path) {

--- a/gen/src/writer/ucd/common.rs
+++ b/gen/src/writer/ucd/common.rs
@@ -8,16 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::path::Path;
 use std::collections::BTreeSet;
+use std::path::Path;
 
 use source::ucd::derived_core_properties::DERIVED_CORE_PROPERTIES;
 use source::ucd::prop_list::PROP_LIST;
 use source::ucd::readme::UNICODE_VERSION;
 use source::ucd::unicode_data::UNICODE_DATA;
 
-use writer::utils::tables::ToRangeCharSet;
 use writer::common::emit_unicode_version;
+use writer::utils::tables::ToRangeCharSet;
 use writer::utils::write;
 
 pub fn generate(dir: &Path) {

--- a/gen/src/writer/ucd/ident.rs
+++ b/gen/src/writer/ucd/ident.rs
@@ -14,8 +14,8 @@ use source::ucd::derived_core_properties::DERIVED_CORE_PROPERTIES;
 use source::ucd::prop_list::PROP_LIST;
 use source::ucd::readme::UNICODE_VERSION;
 
-use writer::utils::tables::ToRangeCharSet;
 use writer::common::emit_unicode_version;
+use writer::utils::tables::ToRangeCharSet;
 use writer::utils::write;
 
 pub fn generate(dir: &Path) {

--- a/gen/src/writer/ucd/name.rs
+++ b/gen/src/writer/ucd/name.rs
@@ -13,11 +13,11 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
 use std::path::Path;
 
-use source::ucd::unicode_data::UNICODE_DATA;
 use source::ucd::readme::UNICODE_VERSION;
+use source::ucd::unicode_data::UNICODE_DATA;
 
-use writer::utils::tables::ToDirectCharTable;
 use writer::common::emit_unicode_version;
+use writer::utils::tables::ToDirectCharTable;
 use writer::utils::write;
 
 pub fn generate(dir: &Path) {

--- a/gen/src/writer/ucd/normal.rs
+++ b/gen/src/writer/ucd/normal.rs
@@ -12,13 +12,13 @@ use std::char;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
-use source::ucd::unicode_data::UNICODE_DATA;
 use source::ucd::derived_normalization_props::COMPOSITION_EXCLUSIONS;
 use source::ucd::readme::UNICODE_VERSION;
+use source::ucd::unicode_data::UNICODE_DATA;
 
+use writer::common::emit_unicode_version;
 use writer::utils::{capitalize, write};
 use writer::utils::tables::{ToDirectCharTable, ToRangeCharSet, ToRangeCharTable};
-use writer::common::emit_unicode_version;
 
 pub fn generate(dir: &Path) {
     emit_unicode_version(dir, &UNICODE_VERSION);

--- a/gen/src/writer/ucd/segment.rs
+++ b/gen/src/writer/ucd/segment.rs
@@ -15,8 +15,8 @@ use source::ucd::readme::UNICODE_VERSION;
 use source::ucd::sentence_break_property::SENTENCE_BREAK_DATA;
 use source::ucd::word_break_property::WORD_BREAK_DATA;
 
-use writer::utils::tables::ToRangeCharTable;
 use writer::common::emit_unicode_version;
+use writer::utils::tables::ToRangeCharTable;
 use writer::utils::write;
 
 pub fn generate(dir: &Path) {

--- a/gen/src/writer/ucd/segment_tests.rs
+++ b/gen/src/writer/ucd/segment_tests.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::path::Path;
 use std::collections::BTreeMap;
+use std::path::Path;
 
 use source::ucd::test::grapheme_break_test::{GraphemeBreakTest, GRAPHEME_BREAK_TESTS};
 use source::ucd::test::word_break_test::{WordBreakTest, WORD_BREAK_TESTS};

--- a/gen/src/writer/utils/tables/direct.rs
+++ b/gen/src/writer/utils/tables/direct.rs
@@ -45,9 +45,9 @@ impl<T> ToDirectCharTable<T> for BTreeMap<char, T> {
 
 #[cfg(test)]
 mod test {
+    use super::ToDirectCharTable;
     use std::collections::BTreeMap;
     use std::fmt::Display;
-    use super::ToDirectCharTable;
 
     #[test]
     fn simple_single_bsearch_map() {

--- a/gen/src/writer/utils/tables/mod.rs
+++ b/gen/src/writer/utils/tables/mod.rs
@@ -14,9 +14,9 @@ mod direct;
 
 use std::fmt;
 
+pub use self::direct::ToDirectCharTable;
 pub use self::range::ToRangeCharTable;
 pub use self::set::ToRangeCharSet;
-pub use self::direct::ToDirectCharTable;
 
 #[derive(Debug)]
 struct DisplayWrapper<'a, T: 'a, F: 'a>(&'a T, &'a F)

--- a/gen/src/writer/utils/tables/range.rs
+++ b/gen/src/writer/utils/tables/range.rs
@@ -64,9 +64,9 @@ impl<T: Eq> ToRangeCharTable<T> for BTreeMap<char, T> {
 
 #[cfg(test)]
 mod test {
+    use super::ToRangeCharTable;
     use std::collections::BTreeMap;
     use std::fmt::Display;
-    use super::ToRangeCharTable;
 
     #[test]
     fn simple_range_bsearch_map() {

--- a/unic/bidi/src/bidi_info.rs
+++ b/unic/bidi/src/bidi_info.rs
@@ -19,10 +19,10 @@ use unic_ucd_bidi::BidiClass;
 use unic_ucd_bidi::bidi_class::abbr_names::*;
 
 use explicit;
+use format_chars;
 use implicit;
 use level;
 use prepare;
-use format_chars;
 
 use level::{Level, LTR_LEVEL, RTL_LEVEL};
 use prepare::LevelRun;
@@ -776,8 +776,8 @@ mod tests {
 
 #[cfg(all(feature = "serde", test))]
 mod serde_tests {
-    use serde_test::{assert_tokens, Token};
     use super::*;
+    use serde_test::{assert_tokens, Token};
 
     #[test]
     fn test_levels() {

--- a/unic/bidi/src/implicit.rs
+++ b/unic/bidi/src/implicit.rs
@@ -16,8 +16,8 @@ use std::cmp::max;
 use unic_ucd_bidi::BidiClass;
 use unic_ucd_bidi::bidi_class::abbr_names::*;
 
-use super::prepare::{IsolatingRunSequence, LevelRun, not_removed_by_x9, removed_by_x9};
 use super::level::Level;
+use super::prepare::{IsolatingRunSequence, LevelRun, not_removed_by_x9, removed_by_x9};
 
 /// 3.3.4 Resolving Weak Types
 ///

--- a/unic/bidi/src/level.rs
+++ b/unic/bidi/src/level.rs
@@ -370,8 +370,8 @@ mod tests {
 
 #[cfg(all(feature = "serde", test))]
 mod serde_tests {
-    use serde_test::{assert_tokens, Token};
     use super::*;
+    use serde_test::{assert_tokens, Token};
 
     #[test]
     fn test_statics() {

--- a/unic/bidi/src/lib.rs
+++ b/unic/bidi/src/lib.rs
@@ -77,8 +77,8 @@ extern crate serde;
 #[cfg(all(feature = "serde", test))]
 extern crate serde_test;
 
-pub use unic_ucd_bidi::UNICODE_VERSION;
 pub use unic_ucd_bidi::{bidi_class, BidiClass, BidiClassCategory};
+pub use unic_ucd_bidi::UNICODE_VERSION;
 
 mod pkg_info;
 pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};

--- a/unic/bidi/src/lib.rs
+++ b/unic/bidi/src/lib.rs
@@ -10,8 +10,8 @@
 // except according to those terms.
 
 #![forbid(future_incompatible, missing_debug_implementations, missing_docs,
-          unconditional_recursion, unsafe_code, unused, unused_imports)]
-#![deny(bad_style)]
+          unconditional_recursion, unsafe_code, unused_imports)]
+#![deny(bad_style, unused)]
 
 //! # UNIC — Unicode Bidirectional Algorithm
 //!

--- a/unic/bidi/src/lib.rs
+++ b/unic/bidi/src/lib.rs
@@ -9,7 +9,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![forbid(unsafe_code, missing_docs)]
+#![forbid(future_incompatible, missing_debug_implementations, missing_docs,
+          unconditional_recursion, unsafe_code, unused, unused_imports)]
+#![deny(bad_style)]
 
 //! # UNIC — Unicode Bidirectional Algorithm
 //!

--- a/unic/bidi/src/lib.rs
+++ b/unic/bidi/src/lib.rs
@@ -10,7 +10,7 @@
 // except according to those terms.
 
 #![forbid(future_incompatible, missing_debug_implementations, missing_docs,
-          unconditional_recursion, unsafe_code, unused_imports)]
+          unconditional_recursion, unsafe_code)]
 #![deny(bad_style, unused)]
 
 //! # UNIC — Unicode Bidirectional Algorithm

--- a/unic/char/property/src/lib.rs
+++ b/unic/char/property/src/lib.rs
@@ -9,7 +9,8 @@
 // except according to those terms.
 
 #![no_std]
-#![forbid(unsafe_code, unconditional_recursion, missing_docs)]
+#![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
+          unconditional_recursion, unsafe_code, unused, unused_imports)]
 
 //! # UNIC — Unicode Character Tools - Character Property
 //!

--- a/unic/char/property/src/lib.rs
+++ b/unic/char/property/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![no_std]
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
-          unconditional_recursion, unsafe_code, unused, unused_imports)]
+          unconditional_recursion, unsafe_code, unused)]
 
 //! # UNIC — Unicode Character Tools - Character Property
 //!

--- a/unic/char/property/src/tables.rs
+++ b/unic/char/property/src/tables.rs
@@ -67,6 +67,7 @@ impl<V: Copy + Default> CharDataTable<V> {
 }
 
 /// Iterator for `CharDataTable`. Iterates over pairs `(CharRange, V)`.
+#[derive(Debug)]
 pub struct CharDataTableIter<'a, V: 'static>(&'a CharDataTable<V>, usize);
 
 impl<'a, V: Copy> Iterator for CharDataTableIter<'a, V> {

--- a/unic/char/range/src/lib.rs
+++ b/unic/char/range/src/lib.rs
@@ -12,7 +12,7 @@
 #![cfg_attr(feature = "exact-size-is-empty", feature(exact_size_is_empty))]
 #![cfg_attr(feature = "fused", feature(fused))]
 #![cfg_attr(feature = "trusted-len", feature(trusted_len))]
-#![forbid(bad_style, missing_debug_implementations, unconditional_recursion, unused_imports)]
+#![forbid(bad_style, missing_debug_implementations, unconditional_recursion)]
 #![deny(missing_docs, unsafe_code, unused, future_incompatible)]
 
 //! # UNIC — Unicode Character Tools - Character Range

--- a/unic/char/range/src/lib.rs
+++ b/unic/char/range/src/lib.rs
@@ -12,7 +12,7 @@
 #![cfg_attr(feature = "exact-size-is-empty", feature(exact_size_is_empty))]
 #![cfg_attr(feature = "fused", feature(fused))]
 #![cfg_attr(feature = "trusted-len", feature(trusted_len))]
-#![forbid(bad_style, missing_debug_implementations, unconditional_recursion)]
+#![forbid(bad_style, missing_debug_implementations, unconditional_recursion, unused_imports)]
 #![deny(missing_docs, unsafe_code, unused, future_incompatible)]
 
 //! # UNIC — Unicode Character Tools - Character Range

--- a/unic/char/src/lib.rs
+++ b/unic/char/src/lib.rs
@@ -12,7 +12,8 @@
 //!
 //! A component of [`unic`: Unicode and Internationalization Crates for Rust](/unic/).
 
-#![forbid(missing_docs)]
+#![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
+          unconditional_recursion, unused, unused_imports)]
 #![deny(unsafe_code)]
 
 pub extern crate unic_char_property as property;

--- a/unic/char/src/lib.rs
+++ b/unic/char/src/lib.rs
@@ -13,7 +13,7 @@
 //! A component of [`unic`: Unicode and Internationalization Crates for Rust](/unic/).
 
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
-          unconditional_recursion, unused, unused_imports)]
+          unconditional_recursion, unused)]
 #![deny(unsafe_code)]
 
 pub extern crate unic_char_property as property;

--- a/unic/common/src/lib.rs
+++ b/unic/common/src/lib.rs
@@ -9,7 +9,8 @@
 // except according to those terms.
 
 #![no_std]
-#![forbid(unsafe_code, missing_docs, unconditional_recursion)]
+#![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
+          unconditional_recursion, unsafe_code, unused, unused_imports)]
 #![cfg_attr(feature = "unstable", feature(unicode))]
 
 //! # UNIC — Common Utilities

--- a/unic/common/src/lib.rs
+++ b/unic/common/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![no_std]
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
-          unconditional_recursion, unsafe_code, unused, unused_imports)]
+          unconditional_recursion, unsafe_code, unused)]
 #![cfg_attr(feature = "unstable", feature(unicode))]
 
 //! # UNIC — Common Utilities

--- a/unic/emoji/char/src/lib.rs
+++ b/unic/emoji/char/src/lib.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, unconditional_recursion,
-          unsafe_code, unused_imports)]
+          unsafe_code)]
 #![deny(missing_docs, unused)]
 
 //! # UNIC — Unicode Emoji — Emoji Character Properties

--- a/unic/emoji/char/src/lib.rs
+++ b/unic/emoji/char/src/lib.rs
@@ -8,8 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![forbid(unsafe_code, unconditional_recursion)]
-#![deny(missing_docs)]
+#![forbid(bad_style, future_incompatible, missing_debug_implementations, unconditional_recursion,
+          unsafe_code, unused_imports)]
+#![deny(missing_docs, unused)]
 
 //! # UNIC — Unicode Emoji — Emoji Character Properties
 //!

--- a/unic/emoji/src/lib.rs
+++ b/unic/emoji/src/lib.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
-          unconditional_recursion, unsafe_code, unused, unused_imports)]
+          unconditional_recursion, unsafe_code, unused)]
 
 //! # UNIC — Unicode Emoji
 //!

--- a/unic/emoji/src/lib.rs
+++ b/unic/emoji/src/lib.rs
@@ -8,7 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![forbid(unsafe_code, missing_docs, unconditional_recursion)]
+#![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
+          unconditional_recursion, unsafe_code, unused, unused_imports)]
 
 //! # UNIC — Unicode Emoji
 //!

--- a/unic/examples/normal_example.rs
+++ b/unic/examples/normal_example.rs
@@ -13,8 +13,8 @@
 
 extern crate unic;
 
-use unic::ucd::normal::compose;
 use unic::normal::StrNormalForm;
+use unic::ucd::normal::compose;
 
 fn main() {
     assert_eq!(compose('A', '\u{30a}'), Some('Å'));

--- a/unic/idna/mapping/src/lib.rs
+++ b/unic/idna/mapping/src/lib.rs
@@ -10,7 +10,7 @@
 // except according to those terms.
 
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
-          unconditional_recursion, unsafe_code, unused, unused_imports)]
+          unconditional_recursion, unsafe_code, unused)]
 
 //! # UNIC - IDNA - IDNA Mapping Table
 //!

--- a/unic/idna/mapping/src/lib.rs
+++ b/unic/idna/mapping/src/lib.rs
@@ -9,7 +9,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![forbid(unsafe_code, missing_docs)]
+#![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
+          unconditional_recursion, unsafe_code, unused, unused_imports)]
 
 //! # UNIC - IDNA - IDNA Mapping Table
 //!

--- a/unic/idna/punycode/src/lib.rs
+++ b/unic/idna/punycode/src/lib.rs
@@ -9,8 +9,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![deny(unsafe_code)]
-#![forbid(missing_docs)]
+#![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
+          unconditional_recursion, unused)]
+#![deny(unsafe_code, unused_imports)]
 
 //! # UNIC — IDNA — Punycode (RFC 3492)
 //!

--- a/unic/idna/punycode/src/lib.rs
+++ b/unic/idna/punycode/src/lib.rs
@@ -23,8 +23,8 @@
 //! `encode_str` and `decode_to_string` provide convenience wrappers
 //! that convert from and to Rust’s UTF-8 based `str` and `String` types.
 
-use std::u32;
 use std::char;
+use std::u32;
 
 // TODO: Drop following after MIN_RUST_VERSION >= 1.23
 #[allow(unused_imports)]

--- a/unic/idna/punycode/tests/punycode_tests.rs
+++ b/unic/idna/punycode/tests/punycode_tests.rs
@@ -12,8 +12,8 @@
 extern crate rustc_serialize;
 extern crate unic_idna_punycode;
 
-use unic_idna_punycode::{decode, encode_str};
 use rustc_serialize::json::{self, Json};
+use unic_idna_punycode::{decode, encode_str};
 
 #[test]
 fn test_punycode_js_data() {

--- a/unic/idna/src/lib.rs
+++ b/unic/idna/src/lib.rs
@@ -54,6 +54,6 @@ pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 pub use mapping::UNICODE_VERSION;
 
 mod process;
-pub use process::PUNYCODE_PREFIX;
 pub use process::{Errors, Flags};
 pub use process::{to_ascii, to_unicode};
+pub use process::PUNYCODE_PREFIX;

--- a/unic/idna/src/lib.rs
+++ b/unic/idna/src/lib.rs
@@ -9,7 +9,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![forbid(unsafe_code, missing_docs)]
+#![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
+          unconditional_recursion, unsafe_code, unused)]
+#![deny(unused_imports)]
 
 //! # UNIC — Unicode IDNA Compatibility Processing
 //!

--- a/unic/idna/src/process.rs
+++ b/unic/idna/src/process.rs
@@ -273,7 +273,7 @@ fn processing(domain: &str, flags: Flags, errors: &mut Vec<Error>) -> String {
 }
 
 /// Optional settings for processing and conversion algorithms.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Flags {
     /// *UseSTD3ASCIIRules* flag.
     ///

--- a/unic/normal/src/decompose.rs
+++ b/unic/normal/src/decompose.rs
@@ -34,14 +34,14 @@ fn canonical_sort(comb: &mut VecDeque<(char, CanonicalCombiningClass)>) {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum DecompositionType {
     Canonical,
     Compatible,
 }
 
 /// External iterator for a string decomposition's characters.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Decompositions<I> {
     kind: DecompositionType,
     iter: I,

--- a/unic/normal/src/decompose.rs
+++ b/unic/normal/src/decompose.rs
@@ -9,8 +9,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt::{self, Write};
 use std::collections::VecDeque;
+use std::fmt::{self, Write};
 
 use unic_ucd_normal::{decompose_canonical, decompose_compatible, CanonicalCombiningClass};
 use unic_ucd_normal::canonical_combining_class::values as ccc;

--- a/unic/normal/src/lib.rs
+++ b/unic/normal/src/lib.rs
@@ -37,9 +37,9 @@ mod recompose;
 
 use std::str::Chars;
 
-pub use unic_ucd_normal::UNICODE_VERSION;
 pub use decompose::Decompositions;
 pub use recompose::Recompositions;
+pub use unic_ucd_normal::UNICODE_VERSION;
 
 mod pkg_info;
 pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};

--- a/unic/normal/src/lib.rs
+++ b/unic/normal/src/lib.rs
@@ -10,7 +10,7 @@
 // except according to those terms.
 
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
-          unconditional_recursion, unsafe_code, unused_imports)]
+          unconditional_recursion, unsafe_code)]
 #![deny(unused)]
 
 //! # UNIC — Unicode Normalization Forms

--- a/unic/normal/src/lib.rs
+++ b/unic/normal/src/lib.rs
@@ -9,7 +9,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![forbid(unsafe_code, missing_docs)]
+#![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
+          unconditional_recursion, unsafe_code, unused_imports)]
+#![deny(unused)]
 
 //! # UNIC — Unicode Normalization Forms
 //!

--- a/unic/normal/src/recompose.rs
+++ b/unic/normal/src/recompose.rs
@@ -16,7 +16,7 @@ use unic_ucd_normal::{compose, CanonicalCombiningClass};
 
 use decompose::Decompositions;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum RecompositionState {
     Composing,
     Purging,
@@ -24,7 +24,7 @@ enum RecompositionState {
 }
 
 /// External iterator for a string recomposition's characters.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Recompositions<I> {
     iter: Decompositions<I>,
     state: RecompositionState,

--- a/unic/segment/src/lib.rs
+++ b/unic/segment/src/lib.rs
@@ -9,8 +9,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![forbid(bad_style, future_incompatible, missing_docs, unconditional_recursion, unsafe_code,
-          unused_imports)]
+#![forbid(bad_style, future_incompatible, missing_docs, unconditional_recursion, unsafe_code)]
 #![deny(unused)]
 // FIXME: Impl Debug
 #![allow(missing_debug_implementations)]

--- a/unic/segment/src/lib.rs
+++ b/unic/segment/src/lib.rs
@@ -9,6 +9,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![forbid(bad_style, future_incompatible, missing_docs, unconditional_recursion, unsafe_code,
+          unused_imports)]
+#![deny(unused)]
+// FIXME: Impl Debug
+#![allow(missing_debug_implementations)]
+
 //! # UNIC — Unicode Text Segmentation Algorithms
 //!
 //! A component of [`unic`: Unicode and Internationalization Crates for Rust](/unic/).
@@ -69,8 +75,6 @@
 //!     ]
 //! );
 //! ```
-
-#![forbid(unsafe_code, missing_docs)]
 
 extern crate unic_ucd_segment;
 

--- a/unic/segment/src/word.rs
+++ b/unic/segment/src/word.rs
@@ -168,8 +168,8 @@ impl<'a> Iterator for WordBounds<'a> {
 
     #[inline]
     fn next(&mut self) -> Option<&'a str> {
-        use self::WordBoundsState::*;
         use self::FormatExtendType::*;
+        use self::WordBoundsState::*;
 
         if self.string.is_empty() {
             return None;
@@ -400,8 +400,8 @@ impl<'a> Iterator for WordBounds<'a> {
 impl<'a> DoubleEndedIterator for WordBounds<'a> {
     #[inline]
     fn next_back(&mut self) -> Option<&'a str> {
-        use self::WordBoundsState::*;
         use self::FormatExtendType::*;
+        use self::WordBoundsState::*;
         if self.string.is_empty() {
             return None;
         }

--- a/unic/src/lib.rs
+++ b/unic/src/lib.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
-          unconditional_recursion, unsafe_code, unused, unused_imports)]
+          unconditional_recursion, unsafe_code, unused)]
 
 //! # UNIC: Unicode and Internationalization Crates for Rust
 //!

--- a/unic/src/lib.rs
+++ b/unic/src/lib.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![forbid(unsafe_code)]
+#![forbid(unsafe_code, missing_docs)]
 
 //! # UNIC: Unicode and Internationalization Crates for Rust
 //!

--- a/unic/src/lib.rs
+++ b/unic/src/lib.rs
@@ -8,7 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![forbid(unsafe_code, missing_docs)]
+#![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
+          unconditional_recursion, unsafe_code, unused, unused_imports)]
 
 //! # UNIC: Unicode and Internationalization Crates for Rust
 //!

--- a/unic/tests/basics_test.rs
+++ b/unic/tests/basics_test.rs
@@ -13,12 +13,12 @@
 
 extern crate unic;
 
-use unic::ucd::common::is_alphanumeric;
 use unic::bidi::BidiInfo;
 use unic::normal::StrNormalForm;
 use unic::segment::{GraphemeIndices, Graphemes, WordBoundIndices, WordBounds, Words};
-use unic::ucd::normal::compose;
 use unic::ucd::{is_cased, Age, BidiClass, CharAge, CharBidiClass, StrBidiClass, UnicodeVersion};
+use unic::ucd::common::is_alphanumeric;
+use unic::ucd::normal::compose;
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
 #[test]

--- a/unic/ucd/age/src/age.rs
+++ b/unic/ucd/age/src/age.rs
@@ -10,8 +10,8 @@
 
 use core::cmp;
 
-pub use unic_ucd_version::UnicodeVersion;
 use unic_char_property::{CharProperty, CustomCharProperty, PartialCharProperty};
+pub use unic_ucd_version::UnicodeVersion;
 
 /// Represents values of the Unicode character property
 /// [*Age*](https://www.unicode.org/reports/tr44/#Age).

--- a/unic/ucd/age/src/lib.rs
+++ b/unic/ucd/age/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![no_std]
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, unconditional_recursion,
-          unsafe_code, unused, unused_imports)]
+          unsafe_code, unused)]
 #![deny(missing_docs)]
 
 //! # UNIC — UCD — Character Age

--- a/unic/ucd/age/src/lib.rs
+++ b/unic/ucd/age/src/lib.rs
@@ -9,7 +9,8 @@
 // except according to those terms.
 
 #![no_std]
-#![forbid(unsafe_code, unconditional_recursion)]
+#![forbid(bad_style, future_incompatible, missing_debug_implementations, unconditional_recursion,
+          unsafe_code, unused, unused_imports)]
 #![deny(missing_docs)]
 
 //! # UNIC — UCD — Character Age

--- a/unic/ucd/bidi/src/bidi_class.rs
+++ b/unic/ucd/bidi/src/bidi_class.rs
@@ -373,9 +373,9 @@ impl StrBidiClass for str {
 
 #[cfg(test)]
 mod tests {
-    use unic_char_property::EnumeratedCharProperty;
     use super::BidiClass;
     use super::abbr_names::*;
+    use unic_char_property::EnumeratedCharProperty;
 
     #[test]
     fn test_ascii() {

--- a/unic/ucd/bidi/src/lib.rs
+++ b/unic/ucd/bidi/src/lib.rs
@@ -10,8 +10,7 @@
 // except according to those terms.
 
 #![no_std]
-#![forbid(future_incompatible, missing_debug_implementations, unconditional_recursion,
-          unsafe_code, unused_imports)]
+#![forbid(future_incompatible, missing_debug_implementations, unconditional_recursion, unsafe_code)]
 #![deny(bad_style, missing_docs, unused)]
 
 //! # UNIC — UCD — Bidi

--- a/unic/ucd/bidi/src/lib.rs
+++ b/unic/ucd/bidi/src/lib.rs
@@ -10,8 +10,9 @@
 // except according to those terms.
 
 #![no_std]
-#![forbid(unsafe_code, unconditional_recursion)]
-#![deny(missing_docs)]
+#![forbid(future_incompatible, missing_debug_implementations, unconditional_recursion,
+          unsafe_code, unused_imports)]
+#![deny(bad_style, missing_docs, unused)]
 
 //! # UNIC — UCD — Bidi
 //!

--- a/unic/ucd/case/src/lib.rs
+++ b/unic/ucd/case/src/lib.rs
@@ -9,7 +9,9 @@
 // except according to those terms.
 
 #![no_std]
-#![forbid(unsafe_code, unconditional_recursion, missing_docs)]
+#![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
+          unconditional_recursion, unsafe_code, unused_imports)]
+#![deny(unused)]
 
 //! # UNIC — UCD — Case Character Properties
 //!

--- a/unic/ucd/case/src/lib.rs
+++ b/unic/ucd/case/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![no_std]
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
-          unconditional_recursion, unsafe_code, unused_imports)]
+          unconditional_recursion, unsafe_code)]
 #![deny(unused)]
 
 //! # UNIC — UCD — Case Character Properties

--- a/unic/ucd/category/src/category.rs
+++ b/unic/ucd/category/src/category.rs
@@ -315,9 +315,9 @@ impl GeneralCategory {
 
 #[cfg(test)]
 mod tests {
-    use unic_char_property::EnumeratedCharProperty;
     use super::GeneralCategory as GC;
     use core::char;
+    use unic_char_property::EnumeratedCharProperty;
 
     #[test]
     fn test_ascii() {

--- a/unic/ucd/category/src/lib.rs
+++ b/unic/ucd/category/src/lib.rs
@@ -9,7 +9,9 @@
 // except according to those terms.
 
 #![no_std]
-#![deny(unsafe_code, missing_docs, unconditional_recursion)]
+#![forbid(future_incompatible, missing_debug_implementations, missing_docs,
+          unconditional_recursion, unsafe_code, unused_imports)]
+#![deny(bad_style, unused)]
 
 //! # UNIC — UCD — Category
 //!

--- a/unic/ucd/category/src/lib.rs
+++ b/unic/ucd/category/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![no_std]
 #![forbid(future_incompatible, missing_debug_implementations, missing_docs,
-          unconditional_recursion, unsafe_code, unused_imports)]
+          unconditional_recursion, unsafe_code)]
 #![deny(bad_style, unused)]
 
 //! # UNIC — UCD — Category

--- a/unic/ucd/common/src/lib.rs
+++ b/unic/ucd/common/src/lib.rs
@@ -9,7 +9,9 @@
 // except according to those terms.
 
 #![no_std]
-#![forbid(unsafe_code, unconditional_recursion, missing_docs)]
+#![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
+          unconditional_recursion, unsafe_code, unused_imports)]
+#![deny(unused)]
 
 //! # UNIC — UCD — Case Character Properties
 //!

--- a/unic/ucd/common/src/lib.rs
+++ b/unic/ucd/common/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![no_std]
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
-          unconditional_recursion, unsafe_code, unused_imports)]
+          unconditional_recursion, unsafe_code)]
 #![deny(unused)]
 
 //! # UNIC — UCD — Case Character Properties

--- a/unic/ucd/ident/src/lib.rs
+++ b/unic/ucd/ident/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![no_std]
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
-          unconditional_recursion, unsafe_code, unused, unused_imports)]
+          unconditional_recursion, unsafe_code, unused)]
 #![deny(unused)]
 
 //! # UNIC — UCD — Identifier Properties

--- a/unic/ucd/ident/src/lib.rs
+++ b/unic/ucd/ident/src/lib.rs
@@ -9,7 +9,9 @@
 // except according to those terms.
 
 #![no_std]
-#![forbid(unsafe_code, unconditional_recursion, missing_docs)]
+#![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
+          unconditional_recursion, unsafe_code, unused, unused_imports)]
+#![deny(unused)]
 
 //! # UNIC — UCD — Identifier Properties
 //!

--- a/unic/ucd/name/src/lib.rs
+++ b/unic/ucd/name/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![no_std]
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, unconditional_recursion,
-          unsafe_code, unused_imports)]
+          unsafe_code)]
 #![deny(unused)]
 // FIXME: Add docs
 #![allow(missing_docs)]

--- a/unic/ucd/name/src/lib.rs
+++ b/unic/ucd/name/src/lib.rs
@@ -9,7 +9,9 @@
 // except according to those terms.
 
 #![no_std]
-#![forbid(unsafe_code)]
+#![forbid(bad_style, future_incompatible, missing_debug_implementations, unconditional_recursion,
+          unsafe_code, unused_imports)]
+#![deny(unused)]
 // FIXME: Add docs
 #![allow(missing_docs)]
 

--- a/unic/ucd/name/src/lib.rs
+++ b/unic/ucd/name/src/lib.rs
@@ -9,6 +9,9 @@
 // except according to those terms.
 
 #![no_std]
+#![forbid(unsafe_code)]
+// FIXME: Add docs
+#![allow(missing_docs)]
 
 extern crate unic_char_property;
 extern crate unic_ucd_version;

--- a/unic/ucd/name/src/name.rs
+++ b/unic/ucd/name/src/name.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::fmt;
 use core::cmp::Ordering;
+use core::fmt;
 
 pub static PREFIX_HANGUL_SYLLABLE: &'static str = "HANGUL SYLLABLE ";
 pub static PREFIX_CJK_UNIFIED_IDEOGRAPH: &'static str = "CJK UNIFIED IDEOGRAPH-";

--- a/unic/ucd/normal/src/decomposition_type.rs
+++ b/unic/ucd/normal/src/decomposition_type.rs
@@ -174,8 +174,8 @@ impl DecompositionType {
 
 #[cfg(test)]
 mod tests {
-    use unic_char_property::EnumeratedCharProperty;
     use super::DecompositionType as DT;
+    use unic_char_property::EnumeratedCharProperty;
 
     #[test]
     fn test_ascii() {

--- a/unic/ucd/normal/src/gen_cat.rs
+++ b/unic/ucd/normal/src/gen_cat.rs
@@ -38,8 +38,8 @@ pub use self::mark::is_combining_mark;
 
 #[cfg(test)]
 mod tests {
-    use core::char;
     use super::*;
+    use core::char;
 
     #[test]
     fn test_is_combining_mark_ascii() {

--- a/unic/ucd/normal/src/lib.rs
+++ b/unic/ucd/normal/src/lib.rs
@@ -10,8 +10,7 @@
 // except according to those terms.
 
 #![no_std]
-#![forbid(future_incompatible, missing_debug_implementations, unconditional_recursion,
-          unsafe_code, unused_imports)]
+#![forbid(future_incompatible, missing_debug_implementations, unconditional_recursion, unsafe_code)]
 #![deny(bad_style, unsafe_code, missing_docs, unused)]
 
 //! # UNIC — UCD — Normalization

--- a/unic/ucd/normal/src/lib.rs
+++ b/unic/ucd/normal/src/lib.rs
@@ -10,7 +10,9 @@
 // except according to those terms.
 
 #![no_std]
-#![deny(unsafe_code, missing_docs, unconditional_recursion)]
+#![forbid(future_incompatible, missing_debug_implementations, unconditional_recursion,
+          unsafe_code, unused_imports)]
+#![deny(bad_style, unsafe_code, missing_docs, unused)]
 
 //! # UNIC — UCD — Normalization
 //!

--- a/unic/ucd/normal/tests/conformance_tests.rs
+++ b/unic/ucd/normal/tests/conformance_tests.rs
@@ -13,9 +13,9 @@ extern crate unic_char_range;
 
 extern crate unic_ucd_normal;
 
-use unic_ucd_normal::DecompositionType as DT;
-use std::collections::HashSet as Set;
 use std::{char, u32};
+use std::collections::HashSet as Set;
+use unic_ucd_normal::DecompositionType as DT;
 
 const DT_TEST_DATA: &str = include_str!("../../../../data/ucd/test/DecompositionTypeTest.txt");
 

--- a/unic/ucd/segment/src/grapheme_cluster_break.rs
+++ b/unic/ucd/segment/src/grapheme_cluster_break.rs
@@ -348,8 +348,8 @@ impl GraphemeClusterBreak {
 
 #[cfg(test)]
 mod tests {
-    use unic_char_property::EnumeratedCharProperty;
     use super::GraphemeClusterBreak as GCB;
+    use unic_char_property::EnumeratedCharProperty;
 
     #[test]
     fn test_ascii() {

--- a/unic/ucd/segment/src/lib.rs
+++ b/unic/ucd/segment/src/lib.rs
@@ -9,8 +9,7 @@
 // except according to those terms.
 
 #![no_std]
-#![forbid(future_incompatible, missing_debug_implementations, unconditional_recursion,
-          unsafe_code, unused_imports)]
+#![forbid(future_incompatible, missing_debug_implementations, unconditional_recursion, unsafe_code)]
 #![deny(bad_style, missing_docs, unused)]
 
 //! # UNIC — UCD — Segmentation Properties"

--- a/unic/ucd/segment/src/lib.rs
+++ b/unic/ucd/segment/src/lib.rs
@@ -9,8 +9,9 @@
 // except according to those terms.
 
 #![no_std]
-#![forbid(unsafe_code, unconditional_recursion)]
-#![deny(missing_docs)]
+#![forbid(future_incompatible, missing_debug_implementations, unconditional_recursion,
+          unsafe_code, unused_imports)]
+#![deny(bad_style, missing_docs, unused)]
 
 //! # UNIC — UCD — Segmentation Properties"
 //!

--- a/unic/ucd/segment/src/sentence_break.rs
+++ b/unic/ucd/segment/src/sentence_break.rs
@@ -263,8 +263,8 @@ impl SentenceBreak {
 
 #[cfg(test)]
 mod tests {
-    use unic_char_property::EnumeratedCharProperty;
     use super::SentenceBreak as SB;
+    use unic_char_property::EnumeratedCharProperty;
 
     #[test]
     fn test_ascii() {

--- a/unic/ucd/segment/src/word_break.rs
+++ b/unic/ucd/segment/src/word_break.rs
@@ -356,8 +356,8 @@ impl WordBreak {
 
 #[cfg(test)]
 mod tests {
-    use unic_char_property::EnumeratedCharProperty;
     use super::WordBreak as WB;
+    use unic_char_property::EnumeratedCharProperty;
 
     #[test]
     fn test_ascii() {

--- a/unic/ucd/segment/tests/basic_tests.rs
+++ b/unic/ucd/segment/tests/basic_tests.rs
@@ -11,8 +11,8 @@
 extern crate unic_ucd_segment;
 
 use unic_ucd_segment::grapheme_cluster_break::GraphemeClusterBreak as GCB;
-use unic_ucd_segment::word_break::WordBreak as WB;
 use unic_ucd_segment::sentence_break::SentenceBreak as SB;
+use unic_ucd_segment::word_break::WordBreak as WB;
 
 #[test]
 fn test_grapheme_cluster_break_display() {

--- a/unic/ucd/src/lib.rs
+++ b/unic/ucd/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![no_std]
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
-          unconditional_recursion, unsafe_code, unused, unused_imports)]
+          unconditional_recursion, unsafe_code, unused)]
 
 //! # UNIC — Unicode Character Database
 //!

--- a/unic/ucd/src/lib.rs
+++ b/unic/ucd/src/lib.rs
@@ -9,7 +9,8 @@
 // except according to those terms.
 
 #![no_std]
-#![forbid(unsafe_code, missing_docs, unconditional_recursion)]
+#![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
+          unconditional_recursion, unsafe_code, unused, unused_imports)]
 
 //! # UNIC — Unicode Character Database
 //!

--- a/unic/ucd/version/src/lib.rs
+++ b/unic/ucd/version/src/lib.rs
@@ -9,7 +9,8 @@
 // except according to those terms.
 
 #![no_std]
-#![forbid(unsafe_code, missing_docs, unconditional_recursion)]
+#![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
+          unconditional_recursion, unsafe_code, unused, unused_imports)]
 
 //! # UNIC — UCD — Core
 //!

--- a/unic/ucd/version/src/lib.rs
+++ b/unic/ucd/version/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![no_std]
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
-          unconditional_recursion, unsafe_code, unused, unused_imports)]
+          unconditional_recursion, unsafe_code, unused)]
 
 //! # UNIC — UCD — Core
 //!


### PR DESCRIPTION
- Add lint attribute checker for components, to make sure some basic lint rules are enabled everywhere in the library.

- Add missing lint attributes to components. Add FIXME where more work is needed.

- Enable building benches targets, without running them, so the code doesn't rust over time.