### PR TITLE
[ucd] Add examples

### DIFF
--- a/unic/tests/char_range_integration_tests.rs
+++ b/unic/tests/char_range_integration_tests.rs
@@ -32,10 +32,11 @@ fn test_char_range_assigned_normal_planes() {
     let assigned_normal_planes = CharRange::assigned_normal_planes();
 
     for codepoint in CharRange::all() {
+        let notation = unicode_notation(codepoint).to_string();
         // Any character is either...
         assert_eq!(
             (
-                unicode_notation(codepoint).to_string(),
+                &notation,
                 (
                     // assigned in a normal plane
                     assigned_normal_planes.contains(codepoint)
@@ -53,7 +54,7 @@ fn test_char_range_assigned_normal_planes() {
                     || chars!('\u{e0000}'..='\u{e01ef}').contains(codepoint)
                 )
             ),
-            (unicode_notation(codepoint).to_string(), true)
+            (&notation, true)
         );
     }
 }

--- a/unic/ucd/Cargo.toml
+++ b/unic/ucd/Cargo.toml
@@ -25,9 +25,10 @@ unic-ucd-segment = { path = "segment/", version = "0.7.0" }
 unic-ucd-version = { path = "version/", version = "0.7.0" }
 
 [dev-dependencies]
-unic-char-range = { path = "../char/range/", version = "0.7.0" }
-unic-char-property = { path = "../char/property/", version = "0.7.0" }
 matches = "0.1"
+unic-char-basics = { path = "../char/basics/", version = "0.7.0" }
+unic-char-property = { path = "../char/property/", version = "0.7.0" }
+unic-char-range = { path = "../char/range/", version = "0.7.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/ucd/case/Cargo.toml
+++ b/unic/ucd/case/Cargo.toml
@@ -13,7 +13,7 @@ exclude = []
 
 [dependencies]
 unic-char-property = { path = "../../char/property/", version = "0.7.0" }
-unic-char-range = { path = "../../char/range", version = "0.7.0" }
+unic-char-range = { path = "../../char/range/", version = "0.7.0" }
 unic-ucd-version = { path = "../version/", version = "0.7.0" }
 
 [badges]

--- a/unic/ucd/examples/lowercase_chars_with_identity_touppercase.rs
+++ b/unic/ucd/examples/lowercase_chars_with_identity_touppercase.rs
@@ -1,0 +1,42 @@
+// Copyright 2017 The UNIC Project Developers.
+//
+// See the COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate unic_char_basics;
+extern crate unic_char_range;
+extern crate unic_ucd_case;
+extern crate unic_ucd_category;
+
+use unic_char_basics::unicode_notation;
+use unic_char_range::CharRange;
+use unic_ucd_category::GeneralCategory;
+
+fn main() {
+    println!(
+        "# Characters with General_Category(ch) == Lowercase_Letter && toUppercase(ch) == ch"
+    );
+
+    let mut total_count = 0;
+    let mut cond_count = 0;
+    for ch in CharRange::assigned_normal_planes() {
+        if GeneralCategory::of(ch) == GeneralCategory::LowercaseLetter {
+            total_count += 1;
+            // TODO(GH-153): Use unic-case for case manipulation.
+            if ch.to_string() == ch.to_uppercase().collect::<String>() {
+                if cond_count > 0 {
+                    print!(", ");
+                }
+                cond_count += 1;
+                print!("{}", unicode_notation(ch));
+            }
+        }
+    }
+    println!();
+    println!("# Count: {} out of {} Lowercase_Letter characters", cond_count, total_count);
+}

--- a/unic/ucd/examples/uppercase_chars_with_identity_tolowercase.rs
+++ b/unic/ucd/examples/uppercase_chars_with_identity_tolowercase.rs
@@ -1,0 +1,42 @@
+// Copyright 2017 The UNIC Project Developers.
+//
+// See the COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate unic_char_basics;
+extern crate unic_char_range;
+extern crate unic_ucd_case;
+extern crate unic_ucd_category;
+
+use unic_char_basics::unicode_notation;
+use unic_char_range::CharRange;
+use unic_ucd_category::GeneralCategory;
+
+fn main() {
+    println!(
+        "# Characters with General_Category(ch) == Uppercase_Letter && toLowercase(ch) == ch"
+    );
+
+    let mut total_count = 0;
+    let mut cond_count = 0;
+    for ch in CharRange::assigned_normal_planes() {
+        if GeneralCategory::of(ch) == GeneralCategory::UppercaseLetter {
+            total_count += 1;
+            // TODO(GH-153): Use unic-case for case manipulation.
+            if ch.to_string() == ch.to_lowercase().collect::<String>() {
+                if cond_count > 0 {
+                    print!(", ");
+                }
+                cond_count += 1;
+                print!("{}", unicode_notation(ch));
+            }
+        }
+    }
+    println!();
+    println!("# Count: {} out of {} Uppercase_Letter characters", cond_count, total_count);
+}


### PR DESCRIPTION
Add example code for comparing Case properties with `General_Category`:
- `lowercase_chars_with_identity_touppercase`
- `uppercase_chars_with_identity_tolowercase`